### PR TITLE
Handle additional whitespace strings in boxes

### DIFF
--- a/BootstrapInstall.m
+++ b/BootstrapInstall.m
@@ -5,7 +5,7 @@ Get["https://raw.githubusercontent.com/jkuczm/MathematicaBootstrapInstaller/v0.1
 
 BootstrapInstall[
 	"SyntaxAnnotations",
-	"https://github.com/jkuczm/MathematicaSyntaxAnnotations/releases/download/v0.1.1/SyntaxAnnotations.zip",
+	"https://github.com/jkuczm/MathematicaSyntaxAnnotations/releases/download/v0.1.2/SyntaxAnnotations.zip",
 	"AdditionalFailureMessage" ->
 		Sequence[
 			"You can ",

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,10 +1,10 @@
 (* Paclet Info File *)
 
-(* created 2015/03/06*)
+(* created 2015/03/26*)
 
 Paclet[
     Name -> "SyntaxAnnotations",
-    Version -> "0.1.1",
+    Version -> "0.1.2",
     MathematicaVersion -> "6+",
     Description -> "Annotate syntax elements at box level",
     Creator -> "Jakub Kuczmarski",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To load SyntaxAnnotations package evaluate: ``Needs["SyntaxAnnotations`"]``.
 ### Manual installation
 
 1. Download latest released
-   [SyntaxAnnotations.zip](https://github.com/jkuczm/MathematicaSyntaxAnnotations/releases/download/v0.1.1/SyntaxAnnotations.zip)
+   [SyntaxAnnotations.zip](https://github.com/jkuczm/MathematicaSyntaxAnnotations/releases/download/v0.1.2/SyntaxAnnotations.zip)
    file.
 
 2. Extract downloaded `SyntaxAnnotations.zip` to any directory which is on

--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -180,7 +180,7 @@ symbolNameQ[str_String] :=
 		heldSymbol =!= HoldComplete[Null]
 	]
 
-symbolNameQ[_] = False;
+symbolNameQ[_] = False
 
 
 (* ::Subsection:: *)
@@ -209,7 +209,7 @@ undefinedSymbolQ[
 undefinedSymbolQ[sym : _String?symbolNameQ | _Symbol] :=
 	! MemberQ[Language`ExtendedDefinition[sym][[1, 2, ;; -2, 2]], Except[{}]]
 
-undefinedSymbolQ[_] = False;
+undefinedSymbolQ[_] = False
 
 
 (* ::Subsection:: *)

--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -276,13 +276,15 @@ extractLocalVariableNames["Scoping" | "Function"][
 	Alternatives @@ Cases[
 		argBoxes
 		,
-		RowBox[{name_String, $assignmentOperators, _}] :>
+		RowBox[{name_String, ___String?whitespaceQ, $assignmentOperators, __}] :>
 			extractSymbolName[name]
 		,
 		{0, Infinity}
 	] |
 	Alternatives @@ Cases[
-		argBoxes /. RowBox[{_String, $assignmentOperators, _}] -> RowBox[{}]
+		argBoxes /.
+			RowBox[{_String, ___String?whitespaceQ, $assignmentOperators, __}] ->
+				RowBox[{}]
 		,
 		name_String /;
 			StringMatchQ[
@@ -446,7 +448,19 @@ annotateSyntaxInternal[
 		]
 	]
 
-annotateSyntaxInternal[RowBox[{arg1_, "\[Function]", arg2_}], rules_] :=
+annotateSyntaxInternal[
+	RowBox[{
+		whitespace1___String?whitespaceQ,
+		arg1_,
+		whitespace2___String?whitespaceQ,
+		"\[Function]",
+		whitespace3___String?whitespaceQ,
+		arg2_,
+		whitespace4___String?whitespaceQ
+	}]
+	,
+	rules_
+] :=
 	withLocalVariables[
 		"Function",
 		localVarsPatt,
@@ -466,6 +480,8 @@ annotateSyntaxInternal[RowBox[{arg1_, "\[Function]", arg2_}], rules_] :=
 			}
 			,
 			RowBox[{
+				whitespace1
+				,
 				Internal`InheritedBlock[{annotateSyntaxInternal},
 					Unprotect[annotateSyntaxInternal];
 					PrependTo[
@@ -493,9 +509,15 @@ annotateSyntaxInternal[RowBox[{arg1_, "\[Function]", arg2_}], rules_] :=
 					annotateSyntaxInternal[arg1, Prepend[rules, rule]]
 				]
 				,
+				whitespace2
+				,
 				"\[Function]"
 				,
+				whitespace3
+				,
 				annotateSyntaxInternal[arg2, Prepend[rules, rule]]
+				,
+				whitespace4
 			}]
 		]
 	]
@@ -503,7 +525,13 @@ annotateSyntaxInternal[RowBox[{arg1_, "\[Function]", arg2_}], rules_] :=
 annotateSyntaxInternal[
 	RowBox[{
 		funcName : "With" | "Module" | "Block" | "Function", "[",
-			args:RowBox[{arg1_, ",", restArgs___}],
+			args:RowBox[{
+				whitespace1___String?whitespaceQ,
+				arg1_,
+				whitespace2___String?whitespaceQ,
+				",",
+				restArgs___
+			}],
 		"]"
 	}]
 	,
@@ -526,6 +554,8 @@ annotateSyntaxInternal[
 			RowBox[{
 				funcName,
 				"["
+				,
+				whitespace1
 				,
 				RowBox[{
 					Internal`InheritedBlock[{annotateSyntaxInternal},
@@ -554,6 +584,8 @@ annotateSyntaxInternal[
 						];
 						annotateSyntaxInternal[arg1, Prepend[rules, rule]]
 					]
+					,
+					whitespace2
 					,
 					","
 					,
@@ -603,10 +635,19 @@ annotateSyntaxInternal[
 
 annotateSyntaxInternal[
 	boxes : RowBox[{
-		PatternSequence[tag_, tagSep:"/:"] | PatternSequence[],
+		whitespace1___String?whitespaceQ,
+		PatternSequence[
+			tag_,
+			whitespace2___String?whitespaceQ,
+			tagSep:"/:"
+		] | PatternSequence[],
+		whitespace3___String?whitespaceQ,
 		lhs_,
+		whitespace4___String?whitespaceQ,
 		funcName:$patternOperators | $patternDelayedOperators,
-		rhs_
+		whitespace5___String?whitespaceQ,
+		rhs_,
+		whitespace6___String?whitespaceQ
 	}]
 	,
 	rules_
@@ -617,8 +658,9 @@ annotateSyntaxInternal[
 		boxes /. "/:" | $patternOperators | $patternDelayedOperators -> ","
 		,
 		RowBox[{
+			whitespace1,
 			Sequence @@ ReplaceAll[
-				{tag, tagSep, lhs}
+				{tag, whitespace2, tagSep, whitespace3, lhs}
 				,
 				str_String :>
 					annotateSyntaxInternal[
@@ -633,7 +675,11 @@ annotateSyntaxInternal[
 					]
 			]
 			,
+			whitespace4
+			,
 			annotateSyntaxInternal[funcName, rules]
+			,
+			whitespace5
 			,
 			If[MatchQ[funcName, $patternDelayedOperators],
 				annotateSyntaxInternal[
@@ -656,6 +702,8 @@ annotateSyntaxInternal[
 			(* else *),
 				annotateSyntaxInternal[rhs, rules]
 			]
+			,
+			whitespace6
 		}]
 	]
 

--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -73,6 +73,13 @@ symbolNameQ[\"str\"] \
 returns True if given String is valid symbol name, returns False otherwise."
 
 
+whitespaceQ::usage =
+"\
+whitespaceQ[\"str\"] \
+returns True if given String is empty or contains only whitespace characters, \
+returns False otherwise."
+
+
 extractSymbolName::usage =
 "\
 extractSymbolName[\"str\"] \
@@ -174,6 +181,17 @@ symbolNameQ[str_String] :=
 	]
 
 symbolNameQ[_] = False;
+
+
+(* ::Subsection:: *)
+(*whitespaceQ*)
+
+
+whitespaceQ[""] = True
+
+whitespaceQ[str_String] := StringMatchQ[str, Whitespace]
+
+whitespaceQ[_] = False
 
 
 (* ::Subsection:: *)

--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -334,12 +334,25 @@ extractArgs[boxes_, 0] := {boxes} /. SyntaxBox[var_, __] :> var
 extractArgs[arg_String, {min_, max_} /; min <= 1 <= max] := {arg}
 
 extractArgs[RowBox[argsBoxes:{___}], {min_Integer, max:_Integer|Infinity}] :=
-	With[{args = DeleteCases[argsBoxes, ","] /. SyntaxBox[var_, __] :> var},
+	Module[{args},
+		args = argsBoxes /. SyntaxBox[var_, __] :> var;
+		args = DeleteCases[args, _String?whitespaceQ];
+		args =
+			FixedPoint[
+				Replace[#,
+					{l___, PatternSequence[",", ","], r___} :>
+						{l, ",", "", ",", r}
+				]&
+				,
+				args
+			];
+		args = DeleteCases[args, ","];
 		Take[args, {Max[1, min], Min[Length[args], max]}]
 	]
+
 extractArgs[argsBoxes_, {i_}] := extractArgs[argsBoxes, {i, i}]
 
-extractArgs[_, {_, _}] = {};
+extractArgs[_, {_, _}] = {}
 
 
 (* ::Subsection:: *)

--- a/SyntaxAnnotations/Tests/Integration/InputFormBoxes.mt
+++ b/SyntaxAnnotations/Tests/Integration/InputFormBoxes.mt
@@ -1,0 +1,173 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["SyntaxAnnotations`Tests`Integration`InputFormBoxes`", {"MUnit`"}]
+
+
+Get["SyntaxAnnotations`Tests`Integration`init`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+Test[
+	RowBox[{
+		"a_", " ", "/:", " ", "b_", " ", "=", " ", RowBox[{"a", "*", "b"}]
+	}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["a_", "PatternVariable"],
+		" ", "/:", " ",
+		SyntaxBox["b_", "PatternVariable"],
+		" ", "=", " ",
+		RowBox[{
+			SyntaxBox["a", "UndefinedSymbol"],
+			"*",
+			SyntaxBox["b", "UndefinedSymbol"]
+		}]
+	}]
+	,
+	TestID -> "a_ /: b_ = a*b"
+]
+
+
+Test[
+	RowBox[{"a_", " ", ":>", " ", "a"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["a_", "PatternVariable"],
+		" ", ":>", " ",
+		SyntaxBox["a", "PatternVariable", "UndefinedSymbol"]
+	}]
+	,
+	TestID -> "a_ :> a"
+]
+
+
+Test[
+	RowBox[{"Module", "[", RowBox[{
+		RowBox[{"{", RowBox[{"a", " ", "=", " ", "b"}], "}"}],
+		",", " ",
+		RowBox[{"a", "*", "b"}]
+	}], "]"}] // AnnotateSyntax
+	,
+	RowBox[{"Module", "[", RowBox[{
+		RowBox[{"{", RowBox[{
+			SyntaxBox["a", "LocalVariable", "UndefinedSymbol"],
+			" ", "=", " ",
+			SyntaxBox["b", "UndefinedSymbol"]
+		}], "}"}],
+		",", " ",
+		RowBox[{
+			SyntaxBox["a", "LocalVariable", "UndefinedSymbol"],
+			"*",
+			SyntaxBox["b", "UndefinedSymbol"]
+		}]
+	}], "]"}]
+	,
+	TestID -> "Module[{a = b}, a*b]"
+]
+
+
+Test[
+	RowBox[{"Function", "[", RowBox[{
+		RowBox[{"{", RowBox[{"a", ",", " ", "b"}], "}"}],
+		",", " ",
+		RowBox[{"a", "*", "b"}]
+	}], "]"}] // AnnotateSyntax
+	,
+	RowBox[{"Function", "[", RowBox[{
+		RowBox[{"{", RowBox[{
+			SyntaxBox["a", "PatternVariable", "UndefinedSymbol"],
+			",", " ",
+			SyntaxBox["b", "PatternVariable", "UndefinedSymbol"]
+		}], "}"}],
+		",", " ",
+		RowBox[{
+			SyntaxBox["a", "PatternVariable", "UndefinedSymbol"],
+			"*",
+			SyntaxBox["b", "PatternVariable", "UndefinedSymbol"]
+		}]
+	}], "]"}]
+	,
+	TestID -> "Function[{a, b}, a*b]"
+]
+
+
+Test[
+	RowBox[{
+		RowBox[{"{", RowBox[{"a", ",", " ", "b"}], "}"}],
+		" ", "\[Function]", " ",
+		RowBox[{"a", "*", "b"}]
+	}] // AnnotateSyntax
+	,
+	RowBox[{
+		RowBox[{"{", RowBox[{
+			SyntaxBox["a", "PatternVariable", "UndefinedSymbol"],
+			",", " ",
+			SyntaxBox["b", "PatternVariable", "UndefinedSymbol"]
+		}], "}"}],
+		" ", "\[Function]", " ",
+		RowBox[{
+			SyntaxBox["a", "PatternVariable", "UndefinedSymbol"],
+			"*",
+			SyntaxBox["b", "PatternVariable", "UndefinedSymbol"]
+		}]
+	}]
+	,
+	TestID -> "{a, b} \\[Function] a*b"
+]
+
+
+Test[
+	RowBox[{"Table", "[", RowBox[{
+		RowBox[{"a", "*", "b"}],
+		",", " ",
+		RowBox[{"{", RowBox[{"a", ",", " ", "b"}], "}"}]}],
+	"]"}] // AnnotateSyntax
+	,
+	RowBox[{"Table", "[", RowBox[{
+		RowBox[{
+			SyntaxBox["a", "FunctionLocalVariable", "UndefinedSymbol"],
+			"*",
+			SyntaxBox["b", "UndefinedSymbol"]
+		}],
+		",", " ",
+		RowBox[{"{", RowBox[{
+			SyntaxBox["a", "FunctionLocalVariable", "UndefinedSymbol"],
+			",", " ",
+			SyntaxBox["b", "UndefinedSymbol"]
+		}], "}"}]}],
+	"]"}]
+	,
+	TestID -> "Table[a*b, {a, b}]"
+]
+
+
+Test[
+	RowBox[{"Solve", "[", RowBox[{"a", ",", " ", "a"}], "]"}] // AnnotateSyntax
+	,
+	RowBox[{"Solve", "[", RowBox[{
+		SyntaxBox["a", "FunctionLocalVariable", "UndefinedSymbol"],
+		",", " ",
+		SyntaxBox["a", "FunctionLocalVariable", "UndefinedSymbol"]
+	}], "]"}]
+	,
+	TestID -> "Solve[a, a]"
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/SyntaxAnnotations/Tests/Integration/suite.mt
+++ b/SyntaxAnnotations/Tests/Integration/suite.mt
@@ -8,5 +8,6 @@ TestSuite[{
 	"Function.mt",
 	"Functions.mt",
 	"FunctionsNested.mt",
-	"MixedNested.mt"
+	"MixedNested.mt",
+	"InputFormBoxes.mt"
 }]

--- a/SyntaxAnnotations/Tests/Unit/extractArgs.mt
+++ b/SyntaxAnnotations/Tests/Unit/extractArgs.mt
@@ -1,0 +1,262 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["SyntaxAnnotations`Tests`Unit`extractArgs`", {"MUnit`"}]
+
+
+Get["SyntaxAnnotations`"]
+
+PrependTo[$ContextPath, "SyntaxAnnotations`Private`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+(* ::Subsection:: *)
+(*String*)
+
+
+Test[
+	extractArgs["a", {1}]
+	,
+	{"a"}
+	,
+	TestID -> "String: {1}"
+]
+Test[
+	extractArgs["a", {1, 2}]
+	,
+	{"a"}
+	,
+	TestID -> "String: {1, 2}"
+]
+Test[
+	extractArgs["a", {2, Infinity}]
+	,
+	{}
+	,
+	TestID -> "String: {2, Infinity}"
+]
+Test[
+	extractArgs["a", 0]
+	,
+	{"a"}
+	,
+	TestID -> "String: 0"
+]
+
+
+(* ::Subsection:: *)
+(*SyntaxBox*)
+
+
+Test[
+	extractArgs[SyntaxBox["a", type], {1}]
+	,
+	{"a"}
+	,
+	TestID -> "SyntaxBox: {1}"
+]
+Test[
+	extractArgs[SyntaxBox["a", type], {1, 2}]
+	,
+	{"a"}
+	,
+	TestID -> "SyntaxBox: {1, 2}"
+]
+Test[
+	extractArgs[SyntaxBox["a", type], {2, Infinity}]
+	,
+	{}
+	,
+	TestID -> "SyntaxBox: {2, Infinity}"
+]
+Test[
+	extractArgs[SyntaxBox["a", type], 0]
+	,
+	{"a"}
+	,
+	TestID -> "SyntaxBox: 0"
+]
+
+
+(* ::Subsection:: *)
+(*RowBox: two comma separated strings*)
+
+
+Test[
+	extractArgs[RowBox[{"b", ",", "d"}], {1}]
+	,
+	{"b"}
+	,
+	TestID -> "RowBox: two comma separated strings: {1}"
+]
+Test[
+	extractArgs[RowBox[{"b", ",", "d"}], {1, 2}]
+	,
+	{"b", "d"}
+	,
+	TestID -> "RowBox: two comma separated strings: {1, 2}"
+]
+Test[
+	extractArgs[RowBox[{"b", ",", "d"}], {2, Infinity}]
+	,
+	{"d"}
+	,
+	TestID -> "RowBox: two comma separated strings: {2, Infinity}"
+]
+Test[
+	extractArgs[RowBox[{"b", ",", "d"}], 0]
+	,
+	{RowBox[{"b", ",", "d"}]}
+	,
+	TestID -> "RowBox: two comma separated strings: 0"
+]
+
+
+(* ::Subsection:: *)
+(*RowBox: two comma separated symbol strings + whitespace*)
+
+
+Test[
+	extractArgs[RowBox[{"b", " \t", ",", "\n", "d"}], {1}]
+	,
+	{"b"}
+	,
+	TestID -> "RowBox: two comma separated symbol strings + whitespace: {1}"
+]
+Test[
+	extractArgs[RowBox[{"b", " \t", ",", "\n", "d"}], {1, 2}]
+	,
+	{"b", "d"}
+	,
+	TestID -> "RowBox: two comma separated symbol strings + whitespace: {1, 2}"
+]
+Test[
+	extractArgs[RowBox[{"b", " \t", ",", "\n", "d"}], {2, Infinity}]
+	,
+	{"d"}
+	,
+	TestID -> "RowBox: two comma separated symbol strings + whitespace: \
+{2, Infinity}"
+]
+Test[
+	extractArgs[RowBox[{"b", " \t", ",", "\n", "d"}], 0]
+	,
+	{RowBox[{"b", " \t", ",", "\n", "d"}]}
+	,
+	TestID -> "RowBox: two comma separated symbol strings + whitespace: 0"
+]
+
+
+(* ::Subsection:: *)
+(*RowBox: four comma separated strings two whitespace*)
+
+
+Test[
+	extractArgs[RowBox[{"b", ",", "  \t", ",", "", ",", "d"}], {1}]
+	,
+	{"b"}
+	,
+	TestID -> "RowBox: two comma separated symbol strings + whitespace: {1}"
+]
+Test[
+	extractArgs[RowBox[{"b", ",", "  \t", ",", "", ",", "d"}], {1, 2}]
+	,
+	{"b", ""}
+	,
+	TestID -> "RowBox: two comma separated symbol strings + whitespace: {1, 2}"
+]
+Test[
+	extractArgs[RowBox[{"b", ",", "  \t", ",", "", ",", "d"}], {2, Infinity}]
+	,
+	{"", "", "d"}
+	,
+	TestID -> "RowBox: two comma separated symbol strings + whitespace: \
+{2, Infinity}"
+]
+Test[
+	extractArgs[RowBox[{"b", ",", "  \t", ",", "", ",", "d"}], 0]
+	,
+	{RowBox[{"b", ",", "  \t", ",", "", ",", "d"}]}
+	,
+	TestID -> "RowBox: two comma separated symbol strings + whitespace: 0"
+]
+
+
+(* ::Subsection:: *)
+(*Complex*)
+
+
+Test[
+	extractArgs[
+		RowBox[{
+			SyntaxBox["c", "Undefined"], ",",
+			RowBox[{"x", "=", "y"}], ",",
+			"e"
+		}],
+		{1}
+	]
+	,
+	{"c"}
+	,
+	TestID -> "Complex: {1}"
+]
+Test[
+	extractArgs[
+		RowBox[{
+			SyntaxBox["c", "Undefined"], ",",
+			RowBox[{"x", "=", "y"}], ",",
+			"e"
+		}],
+		{1, 2}
+	]
+	,
+	{"c", RowBox[{"x", "=", "y"}]}
+	,
+	TestID -> "Complex: {1, 2}"
+]
+Test[
+	extractArgs[
+		RowBox[{
+			SyntaxBox["c", "Undefined"], ",",
+			RowBox[{"x", "=", "y"}], ",",
+			"e"
+		}],
+		{2, Infinity}
+	]
+	,
+	{RowBox[{"x", "=", "y"}], "e"}
+	,
+	TestID -> "Complex: {2, Infinity}"
+]
+Test[
+	extractArgs[
+		RowBox[{
+			SyntaxBox["c", "Undefined"], ",",
+			RowBox[{"x", "=", "y"}], ",",
+			"e"
+		}],
+		0
+	]
+	,
+	{RowBox[{"c", ",", RowBox[{"x", "=", "y"}], ",", "e"}]}
+	,
+	TestID -> "Complex: 0"
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/SyntaxAnnotations/Tests/Unit/suite.mt
+++ b/SyntaxAnnotations/Tests/Unit/suite.mt
@@ -2,5 +2,6 @@ TestSuite[{
 	"undefinedSymbolQ.mt",
 	"symbolNameQ.mt",
 	"whitespaceQ.mt",
-	"extractSymbolName.mt"
+	"extractSymbolName.mt",
+	"extractArgs.mt"
 }]

--- a/SyntaxAnnotations/Tests/Unit/suite.mt
+++ b/SyntaxAnnotations/Tests/Unit/suite.mt
@@ -1,5 +1,6 @@
 TestSuite[{
 	"undefinedSymbolQ.mt",
 	"symbolNameQ.mt",
+	"whitespaceQ.mt",
 	"extractSymbolName.mt"
 }]

--- a/SyntaxAnnotations/Tests/Unit/whitespaceQ.mt
+++ b/SyntaxAnnotations/Tests/Unit/whitespaceQ.mt
@@ -1,0 +1,102 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["SyntaxAnnotations`Tests`Unit`whitespaceQ`", {"MUnit`"}]
+
+
+Get["SyntaxAnnotations`"]
+
+PrependTo[$ContextPath, "SyntaxAnnotations`Private`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+Test[
+	whitespaceQ[""]
+	,
+	True
+	,
+	TestID -> "empty"
+]
+Test[
+	whitespaceQ[" "]
+	,
+	True
+	,
+	TestID -> "space"
+]
+Test[
+	whitespaceQ["\n"]
+	,
+	True
+	,
+	TestID -> "\\n"
+]
+Test[
+	whitespaceQ["\t"]
+	,
+	True
+	,
+	TestID -> "\\t"
+]
+Test[
+	whitespaceQ[" \t \n  "]
+	,
+	True
+	,
+	TestID -> "whitespace combination"
+]
+
+
+Test[
+	whitespaceQ["1"]
+	,
+	False
+	,
+	TestID -> "integer"
+]
+Test[
+	whitespaceQ["b"]
+	,
+	False
+	,
+	TestID -> "single letter"
+]
+Test[
+	whitespaceQ["$"]
+	,
+	False
+	,
+	TestID -> "dollar sign"
+]
+Test[
+	whitespaceQ["\[UnderBracket]"]
+	,
+	False
+	,
+	TestID -> "\\[UnderBracket]"
+]
+Test[
+	whitespaceQ["Null"]
+	,
+	False
+	,
+	TestID -> "Null"
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/SyntaxAnnotations/Tests/suite.mt
+++ b/SyntaxAnnotations/Tests/suite.mt
@@ -2,7 +2,8 @@ TestSuite[{
 	"Unit/undefinedSymbolQ.mt",
 	"Unit/symbolNameQ.mt",
 	"Unit/whitespaceQ.mt",
-	"Unit/extractSymbolName.mt"
+	"Unit/extractSymbolName.mt",
+	"Unit/extractArgs.mt"
 	,
 	"Integration/Scoping.mt",
 	"Integration/ScopingNested.mt",

--- a/SyntaxAnnotations/Tests/suite.mt
+++ b/SyntaxAnnotations/Tests/suite.mt
@@ -1,6 +1,7 @@
 TestSuite[{
 	"Unit/undefinedSymbolQ.mt",
 	"Unit/symbolNameQ.mt",
+	"Unit/whitespaceQ.mt",
 	"Unit/extractSymbolName.mt"
 	,
 	"Integration/Scoping.mt",

--- a/SyntaxAnnotations/Tests/suite.mt
+++ b/SyntaxAnnotations/Tests/suite.mt
@@ -14,5 +14,6 @@ TestSuite[{
 	"Integration/Function.mt",
 	"Integration/Functions.mt",
 	"Integration/FunctionsNested.mt",
-	"Integration/MixedNested.mt"
+	"Integration/MixedNested.mt",
+	"Integration/InputFormBoxes.mt"
 }]


### PR DESCRIPTION
FrontEnd allows extra whitespace-only strings inside box structures. They appear e.g. after using `Convert To` > `InputForm`.

Some box structures were not recognized, by package functions, if they contained additional whitespace, mentioned above, although FronEnd recognizes and colors them.