### PR TITLE
Fix symbolNameQ

### DIFF
--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -175,9 +175,12 @@ $assignmentOperators = "=" | ":=" | "^=" | "^:="
 symbolNameQ["Null"] = True
 
 symbolNameQ[str_String] :=
-	With[{heldSymbol = Quiet @ ToExpression[str, InputForm, HoldComplete]},
-		MatchQ[heldSymbol, HoldComplete[_Symbol]] &&
-		heldSymbol =!= HoldComplete[Null]
+	And[
+		StringFreeQ[str, WhitespaceCharacter],
+		MatchQ[
+			Quiet @ MakeExpression[str, StandardForm],
+			HoldComplete[Except[Null | Symbol[___], _Symbol]]
+		]
 	]
 
 symbolNameQ[_] = False

--- a/SyntaxAnnotations/Tests/Unit/symbolNameQ.mt
+++ b/SyntaxAnnotations/Tests/Unit/symbolNameQ.mt
@@ -73,6 +73,14 @@ Test[
 ]
 
 Test[
+	symbolNameQ["b "]
+	,
+	False
+	,
+	TestID -> "single letter with witespace"
+]
+
+Test[
 	symbolNameQ["c3"]
 	,
 	True
@@ -213,7 +221,21 @@ Block[
 		,
 		HoldPattern[a]
 		,
-		TestID -> "evaluation leak"
+		TestID -> "evaluation leak: not symbol name"
+	]
+]
+Block[
+	{a, b, c}
+	,
+	a := (b = c);
+	symbolNameQ["a"];
+	
+	TestMatch[
+		b
+		,
+		HoldPattern[b]
+		,
+		TestID -> "evaluation leak: valid symbol name"
 	]
 ]
 
@@ -243,12 +265,51 @@ Test[
 ]
 
 
+Test[
+	symbolNameQ["Symbol[]"]
+	,
+	False
+	,
+	TestID -> "Symbol function call: 0 args"
+]
+Test[
+	symbolNameQ["Symbol[\"a\"]"]
+	,
+	False
+	,
+	TestID -> "Symbol function call: 1 arg"
+]
+Test[
+	symbolNameQ["Symbol[\"a\", b]"]
+	,
+	False
+	,
+	TestID -> "Symbol function call: 2 args"
+]
+
+
+Test[
+	symbolNameQ["SyntaxAnnotations`Tests`Unit`symbolNameQ`tmp`a"]
+	,
+	True
+	,
+	TestID -> "Symbol with explicit context: full context"
+]
+Test[
+	symbolNameQ["`tmp`b"]
+	,
+	True
+	,
+	TestID -> "Symbol with explicit context: subcontext of current context"
+]
+
+
 (* ::Section:: *)
 (*TearDown*)
 
 
-Unprotect["`*"]
-Quiet[Remove["`*"], {Remove::rmnsm}]
+Unprotect["`*", "`*`*"]
+Quiet[Remove["`*", "`*`*"], {Remove::rmnsm}]
 
 
 EndPackage[]


### PR DESCRIPTION
Add handling of symbol names with whitespace characters, and with explicit context names.