### PR TITLE
Annotate infix message name

### DIFF
--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -474,6 +474,47 @@ annotateSyntaxInternal[str_String, rules_] :=
 
 annotateSyntaxInternal[boxes_?AtomQ, _] := boxes
 
+annotateSyntaxInternal[RowBox[{"::"}], _] = RowBox[{"::"}]
+
+annotateSyntaxInternal[
+	RowBox[{sym___, "::", tag___, "::", lang___, "::", excess___}],
+	rules_
+] :=
+	RowBox@Join[
+		annotateSyntaxInternal[#, rules] & /@ {sym},
+		{If[{sym} === {}, SyntaxBox["::", "SyntaxError"], "::"]},
+		SyntaxBox[#, "String"] & /@ {tag},
+		{"::"},
+		SyntaxBox[#, "String"] & /@ {lang},
+		{SyntaxBox["::", "ExcessArgument"]},
+		SyntaxBox[#, "ExcessArgument"] & /@ {excess}
+	]
+
+annotateSyntaxInternal[
+	RowBox[{sym___, "::", tag___, "::", lang___}],
+	rules_
+] :=
+	RowBox@Join[
+		annotateSyntaxInternal[#, rules] & /@ {sym},
+		{If[{sym} === {}, SyntaxBox["::", "SyntaxError"], "::"]},
+		SyntaxBox[#, "String"] & /@ {tag},
+		{If[{lang} === {}, SyntaxBox["::", "SyntaxError"], "::"]},
+		SyntaxBox[#, "String"] & /@ {lang}
+	]
+
+annotateSyntaxInternal[RowBox[{sym___, "::", tag___}], rules_] :=
+	RowBox@Join[
+		annotateSyntaxInternal[#, rules] & /@ {sym},
+		{
+			If[{sym} === {} || {tag} === {},
+				SyntaxBox["::", "SyntaxError"]
+			(* else *),
+				"::"
+			]
+		},
+		SyntaxBox[#, "String"] & /@ {tag}
+	]
+		
 (* Following definition is here for performance reasons only. *)
 annotateSyntaxInternal[
 	RowBox[l_List /;

--- a/SyntaxAnnotations/Tests/Integration/InfixMessageName.mt
+++ b/SyntaxAnnotations/Tests/Integration/InfixMessageName.mt
@@ -1,0 +1,295 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage[
+	"SyntaxAnnotations`Tests`Integration`InfixMessageName`",
+	{"MUnit`"}
+]
+
+
+Get["SyntaxAnnotations`Tests`Integration`init`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+(* ::Subsection:: *)
+(*One operator*)
+
+
+Test[
+	RowBox[{"::"}] // AnnotateSyntax
+	,
+	RowBox[{"::"}]
+	,
+	TestID -> "One operator: ::"
+]
+
+Test[
+	RowBox[{"a", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["a", "UndefinedSymbol"],
+		SyntaxBox["::", "SyntaxError"]
+	}]
+	,
+	TestID -> "One operator: a::"
+]
+Test[
+	RowBox[{"::", "b"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		SyntaxBox["b", "String"]
+	}]
+	,
+	TestID -> "One operator: ::b"
+]
+
+Test[
+	RowBox[{"c", "::", "d"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["c", "UndefinedSymbol"],
+		"::",
+		SyntaxBox["d", "String"]
+	}]
+	,
+	TestID -> "One operator: c::d"
+]
+Test[
+	RowBox[{"e", "f", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["e", "UndefinedSymbol"],
+		SyntaxBox["f", "UndefinedSymbol"],
+		SyntaxBox["::", "SyntaxError"]
+	}]
+	,
+	TestID -> "One operator: e f::"
+]
+Test[
+	RowBox[{"::", "g", "h"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		SyntaxBox["g", "String"],
+		SyntaxBox["h", "String"]
+	}]
+	,
+	TestID -> "One operator: ::g h"
+]
+
+Test[
+	RowBox[{"i", "j", "::", "k", "l"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["i", "UndefinedSymbol"],
+		SyntaxBox["j", "UndefinedSymbol"],
+		"::",
+		SyntaxBox["k", "String"],
+		SyntaxBox["l", "String"]
+	}]
+	,
+	TestID -> "One operator: i j::k l"
+]
+
+
+(* ::Subsection:: *)
+(*Two operators*)
+
+
+Test[
+	RowBox[{"::", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		SyntaxBox["::", "SyntaxError"]
+	}]
+	,
+	TestID -> "Two operators: ::::"
+]
+
+Test[
+	RowBox[{"a", "::", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["a", "UndefinedSymbol"],
+		"::",
+		SyntaxBox["::", "SyntaxError"]
+	}]
+	,
+	TestID -> "Two operators: a::::"
+]
+Test[
+	RowBox[{"::", "b", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		SyntaxBox["b", "String"],
+		SyntaxBox["::", "SyntaxError"]
+	}]
+	,
+	TestID -> "Two operators: ::b::"
+]
+Test[
+	RowBox[{"::", "::", "c"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		"::",
+		SyntaxBox["c", "String"]
+	}]
+	,
+	TestID -> "Two operators: ::::c"
+]
+
+Test[
+	RowBox[{"d", "::", "e", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["d", "UndefinedSymbol"],
+		"::",
+		SyntaxBox["e", "String"],
+		SyntaxBox["::", "SyntaxError"]
+	}]
+	,
+	TestID -> "Two operators: d::e::"
+]
+Test[
+	RowBox[{"f", "::", "::", "g"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["f", "UndefinedSymbol"],
+		"::",
+		"::",
+		SyntaxBox["g", "String"]
+	}]
+	,
+	TestID -> "Two operators: f::::g"
+]
+Test[
+	RowBox[{"::", "h", "::", "i"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		SyntaxBox["h", "String"],
+		"::",
+		SyntaxBox["i", "String"]
+	}]
+	,
+	TestID -> "Two operators: ::h::i"
+]
+
+Test[
+	RowBox[{"j", "::", "k", "::", "l"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["j", "UndefinedSymbol"],
+		"::",
+		SyntaxBox["k", "String"],
+		"::",
+		SyntaxBox["l", "String"]
+	}]
+	,
+	TestID -> "Two operators: j::k::l"
+]
+
+
+(* ::Subsection:: *)
+(*Three operators*)
+
+
+Test[
+	RowBox[{"::", "::", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		"::",
+		SyntaxBox["::", "ExcessArgument"]
+	}]
+	,
+	TestID -> "Three operators: ::::::"
+]
+
+Test[
+	RowBox[{"a", "::", "::", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["a", "UndefinedSymbol"],
+		"::",
+		"::",
+		SyntaxBox["::", "ExcessArgument"]
+	}]
+	,
+	TestID -> "Three operators: a::::::"
+]
+Test[
+	RowBox[{"::", "b", "::", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		SyntaxBox["b", "String"],
+		"::",
+		SyntaxBox["::", "ExcessArgument"]
+	}]
+	,
+	TestID -> "Three operators: ::b::::"
+]
+Test[
+	RowBox[{"::", "::", "c", "::"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		"::",
+		SyntaxBox["c", "String"],
+		SyntaxBox["::", "ExcessArgument"]
+	}]
+	,
+	TestID -> "Three operators: ::::c::"
+]
+Test[
+	RowBox[{"::", "::", "::", "d"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["::", "SyntaxError"],
+		"::",
+		SyntaxBox["::", "ExcessArgument"],
+		SyntaxBox["d", "ExcessArgument"]
+	}]
+	,
+	TestID -> "Three operators: ::::::d"
+]
+
+
+Test[
+	RowBox[{"e", "::", "f", "::", "g", "::", "h"}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["e", "UndefinedSymbol"],
+		"::",
+		SyntaxBox["f", "String"],
+		"::",
+		SyntaxBox["g", "String"],
+		SyntaxBox["::", "ExcessArgument"],
+		SyntaxBox["h", "ExcessArgument"]
+	}]
+	,
+	TestID -> "Three operators: e::f::g::h"
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/SyntaxAnnotations/Tests/Integration/MixedNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/MixedNested.mt
@@ -470,6 +470,131 @@ Test[
 ]
 
 
+(* ::Subsection:: *)
+(*Scopping in InfixMessageName*)
+
+
+Test[
+	RowBox[{
+		RowBox[{"Module", "[", RowBox[{
+			RowBox[{"{", "a", "}"}],
+			",",
+			"a"
+		}], "]"}],
+		"::",
+		"a"
+	}] // AnnotateSyntax
+	,
+	RowBox[{
+		RowBox[{"Module", "[", RowBox[{
+			RowBox[{"{",
+				SyntaxBox["a", "LocalVariable", "UndefinedSymbol"],
+			"}"}],
+			",",
+			SyntaxBox["a", "LocalVariable", "UndefinedSymbol"]
+		}], "]"}],
+		"::",
+		SyntaxBox["a", "String"]
+	}]
+	,
+	TestID -> "Module[{a}, a]::a"
+]
+
+Test[
+	RowBox[{
+		"b",
+		"::",
+		RowBox[{"With", "[", RowBox[{
+			RowBox[{"{", RowBox[{"b", "=", "b"}], "}"}],
+			",",
+			"b"
+		}], "]"}]
+	}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["b", "UndefinedSymbol"],
+		"::",
+		SyntaxBox[
+			RowBox[{"With", "[", RowBox[{
+				RowBox[{"{", RowBox[{"b", "=", "b"}], "}"}],
+				",",
+				"b"
+			}], "]"}]
+			,
+			"String"
+		]
+	}]
+	,
+	TestID -> "b::With[{b = b}, b]"
+]
+
+
+(* ::Subsection:: *)
+(*Functions in InfixMessageName*)
+
+
+Test[
+	RowBox[{
+		"c",
+		"::",
+		"d",
+		"::",
+		RowBox[{"Sum", "[", RowBox[{
+			RowBox[{"c", " ", "d", " ", "e", " ", "f"}],
+			",",
+			RowBox[{"{", RowBox[{"e", ",", "f"}], "}"}]
+		}], "]"}]
+	}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["c", "UndefinedSymbol"],
+		"::",
+		SyntaxBox["d", "String"],
+		"::",
+		SyntaxBox[
+			RowBox[{"Sum", "[", RowBox[{
+				RowBox[{"c", " ", "d", " ", "e", " ", "f"}],
+				",",
+				RowBox[{"{", RowBox[{"e", ",", "f"}], "}"}]
+			}], "]"}]
+			,
+			"String"
+		]
+	}]
+	,
+	TestID -> "c::d::Sum[c d e f, {e, f}]"
+]
+
+
+(* ::Subsection:: *)
+(*Patterns in InfixMessageName*)
+
+
+Test[
+	RowBox[{
+		"sym",
+		"::",
+		"msg",
+		"::",
+		"lang",
+		"::",
+		RowBox[{"x_", "->", "x"}]
+	}] // AnnotateSyntax
+	,
+	RowBox[{
+		SyntaxBox["sym", "UndefinedSymbol"],
+		"::",
+		SyntaxBox["msg", "String"],
+		"::",
+		SyntaxBox["lang", "String"],
+		SyntaxBox["::", "ExcessArgument"],
+		SyntaxBox[RowBox[{"x_", "->", "x"}], "ExcessArgument"]
+	}]
+	,
+	TestID -> "sym::msg::lang::x_->x"
+]
+
+
 (* ::Section:: *)
 (*TearDown*)
 

--- a/SyntaxAnnotations/Tests/Integration/suite.mt
+++ b/SyntaxAnnotations/Tests/Integration/suite.mt
@@ -9,6 +9,7 @@ TestSuite[{
 	"Functions.mt",
 	"FunctionsNested.mt",
 	"Strings.mt",
+	"InfixMessageName.mt",
 	"MixedNested.mt",
 	"InputFormBoxes.mt",
 	"FormattingWhitespace.mt"

--- a/SyntaxAnnotations/Tests/suite.mt
+++ b/SyntaxAnnotations/Tests/suite.mt
@@ -15,6 +15,7 @@ TestSuite[{
 	"Integration/Functions.mt",
 	"Integration/FunctionsNested.mt",
 	"Integration/Strings.mt",
+	"Integration/InfixMessageName.mt",
 	"Integration/MixedNested.mt",
 	"Integration/InputFormBoxes.mt",
 	"Integration/FormattingWhitespace.mt"


### PR DESCRIPTION
Annotations for box representations of `sym::message`, `sym::message::lang`, etc. constructs.