### PR TITLE
Interface change

### DIFF
--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -841,7 +841,7 @@ syntaxStyleBox[boxes_, annotationTypes_] :=
 
 Options[AnnotateSyntax] = {
 	"Annotation" -> Automatic,
-	"BoxesToAnnoattiontypes" :> $BoxesToAnnotationTypes
+	"BoxesToAnnotationTypes" :> $BoxesToAnnotationTypes
 }
 
 
@@ -874,7 +874,7 @@ AnnotateSyntax[boxes_, OptionsPattern[]] :=
 		boxesCleanParsed =
 			annotateSyntaxInternal[
 				boxesClean,
-				OptionValue["BoxesToAnnoattiontypes"]
+				OptionValue["BoxesToAnnotationTypes"]
 			];
 		syntaxPosClean =
 			Position[boxesCleanParsed, _syntaxBox, Heads -> False];

--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -18,29 +18,10 @@ returns boxes with certain subboxes wrapped with boxes identifying their \
 syntactic role."
 
 
-SyntaxBox::usage =
-"\
-SyntaxBox[boxes, {type1, subtype1, ...}, {type2, subtype2, ...}, ...] \
-represents boxes that in an expression perform sytnax roles of given types."
-
-
-NormalizeAnnotationTypes::usage =
-"\
-NormalizeAnnotationTypes[{type1, subtype1, ...}, {type2, subtype2, ...}, ...] \
-returns List of strings with names of dominating annotation types from given \
-sequence of annotation types."
-
-
 $BoxesToAnnotationTypes::usage =
 "\
 $BoxesToAnnotationTypes \
 is List of default rules converting boxes to annotation types."
-
-
-$SyntaxBoxToStyleBox::usage =
-"\
-$SyntaxBoxToStyleBox \
-is List of default rules used to transform syntax boxes to style boxes."
 
 
 (* ::Section:: *)
@@ -78,6 +59,12 @@ whitespaceQ::usage =
 whitespaceQ[\"str1\", \"str2\", ...] \
 returns True if given strings are empty or contain only whitespace or \
 \\[IndentingNewLine] characters, returns False otherwise."
+
+
+syntaxBox::usage =
+"\
+syntaxBox[boxes, {type1, subtype1, ...}, {type2, subtype2, ...}, ...] \
+represents boxes that in an expression perform sytnax roles of given types."
 
 
 extractSymbolName::usage =
@@ -123,7 +110,7 @@ returns List containing given boxes.\
 boxes don't need to represent valid mathematica expression. \
 Second argument of extractArgs accepts same values as second element of \
 \"LocalVariables\" property of SyntaxInformation with addition of 0. \
-All occurrences of SyntaxBox are stripped."
+All occurrences of syntaxBox are stripped."
 
 
 extendedSyntaxInformation::usage =
@@ -152,7 +139,7 @@ from argumentBoxes."
 annotateSyntaxInternal::usage =
 "\
 annotateSyntaxInternal[boxes, rules] \
-returns boxes with certain subboxes wrapped with SyntaxBox identifying their \
+returns boxes with certain subboxes wrapped with syntaxBox identifying their \
 syntactic role. Uses given rules as basis for assignment of syntactic roles \
 to subboxes."
 
@@ -164,6 +151,20 @@ returns position encoded in given \"position expression\" posExpr.\
 
 posExprPosition[posExpr, i] \
 returns position encoded in posExpr with last i elements droped."
+
+
+normalizeAnnotationTypes::usage =
+"\
+normalizeAnnotationTypes[{type1, subtype1, ...}, {type2, subtype2, ...}, ...] \
+returns List of strings with names of dominating annotation types from given \
+sequence of annotation types."
+
+
+syntaxStyleBox::usage =
+"\
+syntaxStyleBox[boxes, annotationTypes] \
+returns StyleBox containing given boxes with proper style for given List of \
+annotationTypes."
 
 
 (* ::Subsection:: *)
@@ -347,15 +348,15 @@ extractLocalVariableNames["PatternName"][boxes_] :=
 (*extractArgs*)
 
 
-extractArgs[SyntaxBox[arg_, __], spec_] := extractArgs[arg, spec]
+extractArgs[syntaxBox[arg_, __], spec_] := extractArgs[arg, spec]
 
-extractArgs[boxes_, 0] := {boxes} /. SyntaxBox[var_, __] :> var
+extractArgs[boxes_, 0] := {boxes} /. syntaxBox[var_, __] :> var
 
 extractArgs[arg_String, {min_, max_} /; min <= 1 <= max] := {arg}
 
 extractArgs[RowBox[argsBoxes:{___}], {min_Integer, max:_Integer|Infinity}] :=
 	Module[{args},
-		args = argsBoxes /. SyntaxBox[var_, __] :> var;
+		args = argsBoxes /. syntaxBox[var_, __] :> var;
 		args =
 			FixedPoint[
 				Replace[#,
@@ -455,7 +456,7 @@ withLocalVariables /: Verbatim[SetDelayed][
 
 annotateSyntaxInternal[str_String, rules_] :=
 	With[{types = ReplaceList[str, rules]},
-		SyntaxBox[str, Sequence @@ types] /; types =!= {}
+		syntaxBox[str, Sequence @@ types] /; types =!= {}
 	]
 
 annotateSyntaxInternal[boxes_?AtomQ, _] := boxes
@@ -468,12 +469,12 @@ annotateSyntaxInternal[
 ] :=
 	RowBox@Join[
 		annotateSyntaxInternal[#, rules] & /@ {sym},
-		{If[{sym} === {}, SyntaxBox["::", "SyntaxError"], "::"]},
-		SyntaxBox[#, "String"] & /@ {tag},
+		{If[{sym} === {}, syntaxBox["::", "SyntaxError"], "::"]},
+		syntaxBox[#, "String"] & /@ {tag},
 		{"::"},
-		SyntaxBox[#, "String"] & /@ {lang},
-		{SyntaxBox["::", "ExcessArgument"]},
-		SyntaxBox[#, "ExcessArgument"] & /@ {excess}
+		syntaxBox[#, "String"] & /@ {lang},
+		{syntaxBox["::", "ExcessArgument"]},
+		syntaxBox[#, "ExcessArgument"] & /@ {excess}
 	]
 
 annotateSyntaxInternal[
@@ -482,10 +483,10 @@ annotateSyntaxInternal[
 ] :=
 	RowBox@Join[
 		annotateSyntaxInternal[#, rules] & /@ {sym},
-		{If[{sym} === {}, SyntaxBox["::", "SyntaxError"], "::"]},
-		SyntaxBox[#, "String"] & /@ {tag},
-		{If[{lang} === {}, SyntaxBox["::", "SyntaxError"], "::"]},
-		SyntaxBox[#, "String"] & /@ {lang}
+		{If[{sym} === {}, syntaxBox["::", "SyntaxError"], "::"]},
+		syntaxBox[#, "String"] & /@ {tag},
+		{If[{lang} === {}, syntaxBox["::", "SyntaxError"], "::"]},
+		syntaxBox[#, "String"] & /@ {lang}
 	]
 
 annotateSyntaxInternal[RowBox[{sym___, "::", tag___}], rules_] :=
@@ -493,12 +494,12 @@ annotateSyntaxInternal[RowBox[{sym___, "::", tag___}], rules_] :=
 		annotateSyntaxInternal[#, rules] & /@ {sym},
 		{
 			If[{sym} === {} || {tag} === {},
-				SyntaxBox["::", "SyntaxError"]
+				syntaxBox["::", "SyntaxError"]
 			(* else *),
 				"::"
 			]
 		},
-		SyntaxBox[#, "String"] & /@ {tag}
+		syntaxBox[#, "String"] & /@ {tag}
 	]
 
 annotateSyntaxInternal[
@@ -749,10 +750,10 @@ posExprPosition[head_[___], i_] := posExprPosition[head, i + 1]
 
 
 (* ::Subsection:: *)
-(*NormalizeAnnotationTypes*)
+(*normalizeAnnotationTypes*)
 
 
-NormalizeAnnotationTypes[types___] :=
+normalizeAnnotationTypes[types___] :=
 	Module[{newTypes = {types}, localScopeConflict = False},
 		newTypes =
 			Replace[
@@ -822,23 +823,16 @@ NormalizeAnnotationTypes[types___] :=
 
 
 (* ::Subsection:: *)
-(*$SyntaxBoxToStyleBox*)
+(*syntaxStyleBox*)
 
 
-$SyntaxBoxToStyleBox = {
-	SyntaxBox[boxes_, types__] :>
-		With[{dominatingTypes = NormalizeAnnotationTypes[types]},
-			If[dominatingTypes === {},
-				boxes
-			(* else *),
-				StyleBox[
-					boxes,
-					CurrentValue[{AutoStyleOptions, # <> "Style"}]& /@
-						dominatingTypes
-				]
-			]
-		]
-	}
+syntaxStyleBox[boxes_, {}] := boxes
+
+syntaxStyleBox[boxes_, annotationTypes_] :=
+	StyleBox[
+		boxes,
+		CurrentValue[{AutoStyleOptions, # <> "Style"}]& /@ annotationTypes
+	]
 
 
 (* ::Subsection:: *)
@@ -846,7 +840,7 @@ $SyntaxBoxToStyleBox = {
 
 
 Options[AnnotateSyntax] = {
-	"BoxRules" :> $SyntaxBoxToStyleBox,
+	"Annotation" -> Automatic,
 	"BoxesToAnnoattiontypes" :> $BoxesToAnnotationTypes
 }
 
@@ -854,6 +848,9 @@ Options[AnnotateSyntax] = {
 AnnotateSyntax[boxes_, OptionsPattern[]] :=
 	Module[
 		{
+			annotation =
+				Replace[OptionValue["Annotation"], Automatic -> syntaxStyleBox]
+			,
 			commentPlaceholder, boxesCommRepl, commPos, boxesComm, ignoredPos,
 			boxesClean, boxesCleanParsed, syntaxPosClean, syntaxPos
 		},
@@ -861,7 +858,7 @@ AnnotateSyntax[boxes_, OptionsPattern[]] :=
 			boxes /. RowBox[{"(*", ___, "*)"}] -> commentPlaceholder;
 		commPos =
 			Position[boxesCommRepl, commentPlaceholder, {-1}, Heads -> False];
-		boxesComm = MapAt[SyntaxBox[#, "Comment"]&, boxes, commPos];
+		boxesComm = MapAt[annotation[#, {"Comment"}]&, boxes, commPos];
 		ignoredPos =
 			Join[
 				Position[boxesCommRepl,
@@ -880,7 +877,7 @@ AnnotateSyntax[boxes_, OptionsPattern[]] :=
 				OptionValue["BoxesToAnnoattiontypes"]
 			];
 		syntaxPosClean =
-			Position[boxesCleanParsed, _SyntaxBox, Heads -> False];
+			Position[boxesCleanParsed, _syntaxBox, Heads -> False];
 		syntaxPos =
 			Extract[
 				Delete[
@@ -891,12 +888,15 @@ AnnotateSyntax[boxes_, OptionsPattern[]] :=
 				posExprPosition
 			];
 		ReplacePart[boxesComm,
-			MapThread[{#1} -> ReplacePart[#2, 1 -> #3] &, {
-				syntaxPos,
-				Extract[boxesCleanParsed, syntaxPosClean],
-				Extract[boxes, syntaxPos]
-			}]
-		] /. OptionValue["BoxRules"]
+			MapThread[
+				{#1} -> annotation[#3, normalizeAnnotationTypes @@ Rest[#2]] &,
+				{
+					syntaxPos,
+					Extract[boxesCleanParsed, syntaxPosClean],
+					Extract[boxes, syntaxPos]
+				}
+			]
+		]
 	]
 
 

--- a/SyntaxAnnotations/Tests/Integration/Function.mt
+++ b/SyntaxAnnotations/Tests/Integration/Function.mt
@@ -21,7 +21,7 @@ Get["SyntaxAnnotations`Tests`Integration`init`"]
 Test[
 	Function[a] // MakeBoxes // AnnotateSyntax
 	,
-	Function[syntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
+	Function[SyntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
 	,
 	TestID -> "Function[a]"
 ]
@@ -29,7 +29,7 @@ Test[
 Test[
 	Function[#] // MakeBoxes // AnnotateSyntax
 	,
-	Function[syntaxExpr[#, "PatternVariable"]] // MakeBoxes
+	Function[SyntaxExpr[#, "PatternVariable"]] // MakeBoxes
 	,
 	TestID -> "Function[#]"
 ]
@@ -37,7 +37,7 @@ Test[
 Test[
 	Function[#2] // MakeBoxes // AnnotateSyntax
 	,
-	Function[syntaxExpr[#2, "PatternVariable"]] // MakeBoxes
+	Function[SyntaxExpr[#2, "PatternVariable"]] // MakeBoxes
 	,
 	TestID -> "Function[#2]"
 ]
@@ -45,7 +45,7 @@ Test[
 Test[
 	Function[##] // MakeBoxes // AnnotateSyntax
 	,
-	Function[syntaxExpr[##, "PatternVariable"]] // MakeBoxes
+	Function[SyntaxExpr[##, "PatternVariable"]] // MakeBoxes
 	,
 	TestID -> "Function[##]"
 ]
@@ -53,7 +53,7 @@ Test[
 Test[
 	Function[##3] // MakeBoxes // AnnotateSyntax
 	,
-	Function[syntaxExpr[##3, "PatternVariable"]] // MakeBoxes
+	Function[SyntaxExpr[##3, "PatternVariable"]] // MakeBoxes
 	,
 	TestID -> "Function[##3]"
 ]
@@ -62,7 +62,7 @@ If[$VersionNumber >= 10,
 	Test[
 		Function[#name] // MakeBoxes // AnnotateSyntax
 		,
-		Function[syntaxExpr[#name, "PatternVariable"]] // MakeBoxes
+		Function[SyntaxExpr[#name, "PatternVariable"]] // MakeBoxes
 		,
 		TestID -> "Function[#name]"
 	]
@@ -81,8 +81,8 @@ Test[
 	Function[a, b] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
-		syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[a, b]"
@@ -92,8 +92,8 @@ Test[
 	Function[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[a, a]"
@@ -103,8 +103,8 @@ Test[
 	Function[a, _a] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
-		syntaxExpr[_a, "PatternVariable"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		SyntaxExpr[_a, "PatternVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[a, _a]"
@@ -114,8 +114,8 @@ Test[
 	Function[a, a_] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
-		syntaxExpr[a_, "PatternVariable"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		SyntaxExpr[a_, "PatternVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[a, a_]"
@@ -125,8 +125,8 @@ Test[
 	Function[_a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[_a, "PatternVariable"],
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[_a, "PatternVariable"],
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[_a, a]"
@@ -135,7 +135,7 @@ Test[
 Test[
 	Function[a_, a] // MakeBoxes // AnnotateSyntax
 	,
-	Function[a_, syntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
+	Function[a_, SyntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
 	,
 	TestID -> "Function[a_, a]"
 ]
@@ -144,8 +144,8 @@ Test[
 	Function[a b, a b] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[a b, a b]"
@@ -155,8 +155,8 @@ Test[
 	Function[a = b, a b] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[a, "UndefinedSymbol"] = syntaxExpr[b, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] = SyntaxExpr[b, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[a = b, a b]"
@@ -171,8 +171,8 @@ Test[
 	Function[{a}, b] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		{syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
-		syntaxExpr[b, "UndefinedSymbol"]
+		{SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
+		SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[{a}, b]"
@@ -182,8 +182,8 @@ Test[
 	Function[{a}, a] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		{syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		{SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[{a}, a]"
@@ -193,8 +193,8 @@ Test[
 	Function[{a}, _a] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		{syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
-		syntaxExpr[_a, "PatternVariable"]
+		{SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
+		SyntaxExpr[_a, "PatternVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[{a}, _a]"
@@ -204,8 +204,8 @@ Test[
 	Function[{a}, a_] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		{syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
-		syntaxExpr[a_, "PatternVariable"]
+		{SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a_, "PatternVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[{a}, a_]"
@@ -215,8 +215,8 @@ Test[
 	Function[{_a}, a] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		{syntaxExpr[_a, "PatternVariable"]},
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		{SyntaxExpr[_a, "PatternVariable"]},
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[{_a}, a]"
@@ -225,7 +225,7 @@ Test[
 Test[
 	Function[{a_}, a] // MakeBoxes // AnnotateSyntax
 	,
-	Function[{a_}, syntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
+	Function[{a_}, SyntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
 	,
 	TestID -> "Function[{a_}, a]"
 ]
@@ -235,12 +235,12 @@ Test[
 	,
 	Function[
 		{
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 		}
 		,
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[{a b}, a b]"
@@ -251,12 +251,12 @@ Test[
 	,
 	Function[
 		{
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] =
-				syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] =
+				SyntaxExpr[b, "UndefinedSymbol"]
 		}
 		,
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[{a = b}, a b]"
@@ -267,12 +267,12 @@ Test[
 	,
 	Function[
 		{
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 		}
 		,
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[{a, b}, a b]"
@@ -287,9 +287,9 @@ Test[
 	Function[a, b, c] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
-		syntaxExpr[b, "UndefinedSymbol"],
-		syntaxExpr[c, "UndefinedSymbol"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		SyntaxExpr[b, "UndefinedSymbol"],
+		SyntaxExpr[c, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[a, b, c]"
@@ -299,9 +299,9 @@ Test[
 	Function[a, a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
-		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Function[a, a, a]"

--- a/SyntaxAnnotations/Tests/Integration/Functions.mt
+++ b/SyntaxAnnotations/Tests/Integration/Functions.mt
@@ -22,8 +22,8 @@ Test[
 	Table[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Table[
-		syntaxExpr[a, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Table[a, a]"
@@ -34,8 +34,8 @@ Test[
 	Table[a, {a}] // MakeBoxes // AnnotateSyntax
 	,
 	Table[
-		syntaxExpr[a, "UndefinedSymbol"],
-		{syntaxExpr[a, "UndefinedSymbol"]}
+		SyntaxExpr[a, "UndefinedSymbol"],
+		{SyntaxExpr[a, "UndefinedSymbol"]}
 	] // MakeBoxes
 	,
 	TestID -> "Table[a, {a}]"
@@ -46,12 +46,12 @@ Test[
 	Table[a b, {a, b}] // MakeBoxes // AnnotateSyntax
 	,
 	Table[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -63,14 +63,14 @@ Test[
 	Table[a b c, {a, b, c}] // MakeBoxes // AnnotateSyntax
 	,
 	Table[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -82,16 +82,16 @@ Test[
 	Table[a b c d, {a, b, c, d}] // MakeBoxes // AnnotateSyntax
 	,
 	Table[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"] *
-		syntaxExpr[d, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[d, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"],
-			syntaxExpr[d, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"],
+			SyntaxExpr[d, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -103,19 +103,19 @@ Test[
 	Table[a b c d, {a, b}, {c, d}] // MakeBoxes // AnnotateSyntax
 	,
 	Table[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[d, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[d, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"]
 		}
 		,
 		{
-			syntaxExpr[c, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[d, "UndefinedSymbol"]
+			SyntaxExpr[c, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[d, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -131,8 +131,8 @@ Test[
 	Plot[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Plot[
-		syntaxExpr[a, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Plot[a, a]"
@@ -143,8 +143,8 @@ Test[
 	Plot[a, {a}] // MakeBoxes // AnnotateSyntax
 	,
 	Plot[
-		syntaxExpr[a, "UndefinedSymbol"],
-		{syntaxExpr[a, "UndefinedSymbol"]}
+		SyntaxExpr[a, "UndefinedSymbol"],
+		{SyntaxExpr[a, "UndefinedSymbol"]}
 	] // MakeBoxes
 	,
 	TestID -> "Plot[a, {a}]"
@@ -155,11 +155,11 @@ Test[
 	Plot[a b, {a, b}] // MakeBoxes // AnnotateSyntax
 	,
 	Plot[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"],
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"],
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -171,13 +171,13 @@ Test[
 	Plot[a b c, {a, b, c}] // MakeBoxes // AnnotateSyntax
 	,
 	Plot[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"],
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"],
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -189,17 +189,17 @@ Test[
 	Plot[a b c d, {a, b}, {c, d}] // MakeBoxes // AnnotateSyntax
 	,
 	Plot[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"] *
-		syntaxExpr[d, "UndefinedSymbol"],
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[d, "UndefinedSymbol"],
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"]
 		},
 		{
-			syntaxExpr[c, "UndefinedSymbol"],
-			syntaxExpr[d, "UndefinedSymbol"]
+			SyntaxExpr[c, "UndefinedSymbol"],
+			SyntaxExpr[d, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -215,8 +215,8 @@ Test[
 	Solve[b, a] // MakeBoxes // AnnotateSyntax
 	,
 	Solve[
-		syntaxExpr[b, "UndefinedSymbol"],
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[b, "UndefinedSymbol"],
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Solve[b, a]"
@@ -227,8 +227,8 @@ Test[
 	Solve[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Solve[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Solve[a, a]"
@@ -238,7 +238,7 @@ Test[
 Test[
 	Solve[a, a_] // MakeBoxes // AnnotateSyntax
 	,
-	Solve[syntaxExpr[a, "UndefinedSymbol"], a_] // MakeBoxes
+	Solve[SyntaxExpr[a, "UndefinedSymbol"], a_] // MakeBoxes
 	,
 	TestID -> "Solve[a, a_]"
 ]
@@ -247,7 +247,7 @@ Test[
 Test[
 	Solve[a, _a] // MakeBoxes // AnnotateSyntax
 	,
-	Solve[syntaxExpr[a, "UndefinedSymbol"], _a] // MakeBoxes
+	Solve[SyntaxExpr[a, "UndefinedSymbol"], _a] // MakeBoxes
 	,
 	TestID -> "Solve[a, _a]"
 ]
@@ -257,8 +257,8 @@ Test[
 	Solve[a, {a}] // MakeBoxes // AnnotateSyntax
 	,
 	Solve[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-		{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]}
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+		{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]}
 	] // MakeBoxes
 	,
 	TestID -> "Solve[a, {a}]"
@@ -269,12 +269,12 @@ Test[
 	Solve[a b, {a, b}] // MakeBoxes // AnnotateSyntax
 	,
 	Solve[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -286,12 +286,12 @@ Test[
 	Solve[a b, a, b] // MakeBoxes // AnnotateSyntax
 	,
 	Solve[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 		,
-		syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Solve[a b, a, b]"
@@ -306,8 +306,8 @@ Test[
 	Limit[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Limit[
-		syntaxExpr[a, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Limit[a, a]"
@@ -318,11 +318,11 @@ Test[
 	Limit[a b, a -> b] // MakeBoxes // AnnotateSyntax
 	,
 	Limit[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
+			SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Limit[a b, a -> b]"
@@ -333,11 +333,11 @@ Test[
 	Limit[a b, a \[Rule] b] // MakeBoxes // AnnotateSyntax
 	,
 	Limit[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
+			SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Limit[a b, a \\[Rule] b]"
@@ -348,8 +348,8 @@ Test[
 	Limit[a b, a :> b] // MakeBoxes // AnnotateSyntax
 	,
 	Limit[
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"] :> syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"] :> SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Limit[a b, :> b]"
@@ -360,15 +360,15 @@ Test[
 	Limit[a b c d, a -> b, c -> d] // MakeBoxes // AnnotateSyntax
 	,
 	Limit[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"] *
-		syntaxExpr[d, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[d, "UndefinedSymbol"]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
+			SyntaxExpr[b, "UndefinedSymbol"]
 		,
-		syntaxExpr[c, "UndefinedSymbol"] -> syntaxExpr[d, "UndefinedSymbol"]
+		SyntaxExpr[c, "UndefinedSymbol"] -> SyntaxExpr[d, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Limit[a b c d, a -> b, c -> d]"
@@ -513,8 +513,8 @@ Test[
 	Sum[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Sum[
-		syntaxExpr[a, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "\[Sum]: Sum[a, a]"
@@ -525,8 +525,8 @@ Test[
 	Sum[a, {a}] // MakeBoxes // AnnotateSyntax
 	,
 	Sum[
-		syntaxExpr[a, "UndefinedSymbol"],
-		{syntaxExpr[a, "UndefinedSymbol"]}
+		SyntaxExpr[a, "UndefinedSymbol"],
+		{SyntaxExpr[a, "UndefinedSymbol"]}
 	] // MakeBoxes
 	,
 	TestID -> "\[Sum]: Sum[a, {a}]"
@@ -537,8 +537,8 @@ Test[
 	Sum[a b, {a, b}] // MakeBoxes // AnnotateSyntax
 	,
 	Sum[
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"],
-		{syntaxExpr[a, "UndefinedSymbol"], syntaxExpr[b, "UndefinedSymbol"]}
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"],
+		{SyntaxExpr[a, "UndefinedSymbol"], SyntaxExpr[b, "UndefinedSymbol"]}
 	] // MakeBoxes
 	,
 	TestID -> "\[Sum]: Sum[a b, {a, b}]"
@@ -549,14 +549,14 @@ Test[
 	Sum[a b c, {a, b, c}] // MakeBoxes // AnnotateSyntax
 	,
 	Sum[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -568,23 +568,23 @@ Test[
 	Sum[a b c d e f, {a, b, c}, {d, e, f}] // MakeBoxes // AnnotateSyntax
 	,
 	Sum[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"] *
-		syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[e, "UndefinedSymbol"] *
-		syntaxExpr[f, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[e, "UndefinedSymbol"] *
+		SyntaxExpr[f, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 		,
 		{
-			syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[e, "UndefinedSymbol"],
-			syntaxExpr[f, "UndefinedSymbol"]
+			SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[e, "UndefinedSymbol"],
+			SyntaxExpr[f, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -731,8 +731,8 @@ Test[
 	Product[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Product[
-		syntaxExpr[a, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "\[Product]: Product[a, a]"
@@ -743,8 +743,8 @@ Test[
 	Product[a, {a}] // MakeBoxes // AnnotateSyntax
 	,
 	Product[
-		syntaxExpr[a, "UndefinedSymbol"],
-		{syntaxExpr[a, "UndefinedSymbol"]}
+		SyntaxExpr[a, "UndefinedSymbol"],
+		{SyntaxExpr[a, "UndefinedSymbol"]}
 	] // MakeBoxes
 	,
 	TestID -> "\[Product]: Product[a, {a}]"
@@ -755,8 +755,8 @@ Test[
 	Product[a b, {a, b}] // MakeBoxes // AnnotateSyntax
 	,
 	Product[
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"],
-		{syntaxExpr[a, "UndefinedSymbol"], syntaxExpr[b, "UndefinedSymbol"]}
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"],
+		{SyntaxExpr[a, "UndefinedSymbol"], SyntaxExpr[b, "UndefinedSymbol"]}
 	] // MakeBoxes
 	,
 	TestID -> "\[Product]: Product[a b, {a, b}]"
@@ -767,14 +767,14 @@ Test[
 	Product[a b c, {a, b, c}] // MakeBoxes // AnnotateSyntax
 	,
 	Product[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -786,23 +786,23 @@ Test[
 	Product[a b c d e f, {a, b, c}, {d, e, f}] // MakeBoxes // AnnotateSyntax
 	,
 	Product[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"] *
-		syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[e, "UndefinedSymbol"] *
-		syntaxExpr[f, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[e, "UndefinedSymbol"] *
+		SyntaxExpr[f, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 		,
 		{
-			syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[e, "UndefinedSymbol"],
-			syntaxExpr[f, "UndefinedSymbol"]
+			SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[e, "UndefinedSymbol"],
+			SyntaxExpr[f, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -929,8 +929,8 @@ Test[
 	Integrate[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	Integrate[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "\[Integral]: Integrate[a, a]"
@@ -940,12 +940,12 @@ Test[
 	Integrate[a b, a, b] // MakeBoxes // AnnotateSyntax
 	,
 	Integrate[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 		,
-		syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "\[Integral]: Integrate[a b, a, b]"
@@ -956,14 +956,14 @@ Test[
 	Integrate[a b c, {a, b, c}] // MakeBoxes // AnnotateSyntax
 	,
 	Integrate[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -974,23 +974,23 @@ Test[
 	Integrate[a b c d e f, {a, b, c}, {d, e, f}] // MakeBoxes // AnnotateSyntax
 	,
 	Integrate[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"] *
-		syntaxExpr[c, "UndefinedSymbol"] *
-		syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[e, "UndefinedSymbol"] *
-		syntaxExpr[f, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[e, "UndefinedSymbol"] *
+		SyntaxExpr[f, "UndefinedSymbol"]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 		,
 		{
-			syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[e, "UndefinedSymbol"],
-			syntaxExpr[f, "UndefinedSymbol"]
+			SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[e, "UndefinedSymbol"],
+			SyntaxExpr[f, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -1012,7 +1012,7 @@ Module[
 	Test[
 		customFunction[a] // MakeBoxes // AnnotateSyntax
 		,
-		customFunction[syntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
+		customFunction[SyntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
 		,
 		TestID -> "customFunction[a]"
 	];
@@ -1021,8 +1021,8 @@ Module[
 		customFunction[a, a] // MakeBoxes // AnnotateSyntax
 		,
 		customFunction[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 		] // MakeBoxes
 		,
 		TestID -> "customFunction[a, a]"
@@ -1032,12 +1032,12 @@ Module[
 		customFunction[a b, a, b] // MakeBoxes // AnnotateSyntax
 		,
 		customFunction[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 			,
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 			,
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 		] // MakeBoxes
 		,
 		TestID -> "customFunction[a b, a, b]"
@@ -1047,15 +1047,15 @@ Module[
 		customFunction[a b c, a, b, c] // MakeBoxes // AnnotateSyntax
 		,
 		customFunction[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[c, "UndefinedSymbol"]
 			,
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 			,
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 			,
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[c, "UndefinedSymbol"]
 		] // MakeBoxes
 		,
 		TestID -> "customFunction[a b c, a, b, c]"
@@ -1065,14 +1065,14 @@ Module[
 		customFunction[a b c, {a, b, c}] // MakeBoxes // AnnotateSyntax
 		,
 		customFunction[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] *
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] *
+			SyntaxExpr[c, "UndefinedSymbol"]
 			,
 			{
-				syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-				syntaxExpr[b, "UndefinedSymbol"],
-				syntaxExpr[c, "UndefinedSymbol"]
+				SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+				SyntaxExpr[b, "UndefinedSymbol"],
+				SyntaxExpr[c, "UndefinedSymbol"]
 			}
 		] // MakeBoxes
 		,
@@ -1090,8 +1090,8 @@ Module[
 		customFunctionNoSI[a, b] // MakeBoxes // AnnotateSyntax
 		,
 		customFunctionNoSI[
-			syntaxExpr[a, "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"]
 		] // MakeBoxes
 		,
 		TestID -> "defined customFunctionNoSI[a, b]"
@@ -1106,9 +1106,9 @@ Module[
 	Test[
 		customFunctionNoSINoDefinition[a, b] // MakeBoxes // AnnotateSyntax
 		,
-		syntaxExpr[customFunctionNoSINoDefinition, "UndefinedSymbol"][
-			syntaxExpr[a, "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[customFunctionNoSINoDefinition, "UndefinedSymbol"][
+			SyntaxExpr[a, "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"]
 		] // MakeBoxes
 		,
 		TestID -> "undefined customFunctionNoSINoDefinition[a, b]"

--- a/SyntaxAnnotations/Tests/Integration/FunctionsNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/FunctionsNested.mt
@@ -26,24 +26,24 @@ Test[
 	,
 	Table[
 		Table[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] *
-			syntaxExpr[c, "UndefinedSymbol"] *
-			syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[e, "UndefinedSymbol"] *
-			syntaxExpr[f, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] *
+			SyntaxExpr[c, "UndefinedSymbol"] *
+			SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[e, "UndefinedSymbol"] *
+			SyntaxExpr[f, "UndefinedSymbol"]
 			,
 			{
-				syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-				syntaxExpr[b, "UndefinedSymbol"],
-				syntaxExpr[c, "UndefinedSymbol"]
+				SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+				SyntaxExpr[b, "UndefinedSymbol"],
+				SyntaxExpr[c, "UndefinedSymbol"]
 			}
 		]
 		,
 		{
-			syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[e, "UndefinedSymbol"],
-			syntaxExpr[f, "UndefinedSymbol"]
+			SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[e, "UndefinedSymbol"],
+			SyntaxExpr[f, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -56,21 +56,21 @@ Test[
 	,
 	Table[
 		Table[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] *
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] *
+			SyntaxExpr[c, "UndefinedSymbol"]
 			,
 			{
-				syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-				syntaxExpr[b, "UndefinedSymbol"],
-				syntaxExpr[c, "UndefinedSymbol"]
+				SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+				SyntaxExpr[b, "UndefinedSymbol"],
+				SyntaxExpr[c, "UndefinedSymbol"]
 			}
 		]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -88,24 +88,24 @@ Test[
 	,
 	Plot[
 		Plot[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] *
-			syntaxExpr[c, "UndefinedSymbol"] *
-			syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[e, "UndefinedSymbol"] *
-			syntaxExpr[f, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] *
+			SyntaxExpr[c, "UndefinedSymbol"] *
+			SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[e, "UndefinedSymbol"] *
+			SyntaxExpr[f, "UndefinedSymbol"]
 			,
 			{
-				syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-				syntaxExpr[b, "UndefinedSymbol"],
-				syntaxExpr[c, "UndefinedSymbol"]
+				SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+				SyntaxExpr[b, "UndefinedSymbol"],
+				SyntaxExpr[c, "UndefinedSymbol"]
 			}
 		]
 		,
 		{
-			syntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[e, "UndefinedSymbol"],
-			syntaxExpr[f, "UndefinedSymbol"]
+			SyntaxExpr[d, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[e, "UndefinedSymbol"],
+			SyntaxExpr[f, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -118,21 +118,21 @@ Test[
 	,
 	Plot[
 		Plot[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] *
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] *
+			SyntaxExpr[c, "UndefinedSymbol"]
 			,
 			{
-				syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-				syntaxExpr[b, "UndefinedSymbol"],
-				syntaxExpr[c, "UndefinedSymbol"]
+				SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+				SyntaxExpr[b, "UndefinedSymbol"],
+				SyntaxExpr[c, "UndefinedSymbol"]
 			}
 		]
 		,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -149,13 +149,13 @@ Test[
 	,
 	Solve[
 		Solve[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 			,
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 		]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Solve[Solve[a b, b], a]"
@@ -167,11 +167,11 @@ Test[
 	,
 	Solve[
 		Solve[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 		]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Solve[Solve[a, a], a]"
@@ -187,17 +187,17 @@ Test[
 	,
 	Limit[
 		Limit[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] *
-			syntaxExpr[c, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[d, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] *
+			SyntaxExpr[c, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[d, "UndefinedSymbol"]
 			,
-			syntaxExpr[c, "FunctionLocalVariable", "UndefinedSymbol"] ->
-				syntaxExpr[d, "UndefinedSymbol"]
+			SyntaxExpr[c, "FunctionLocalVariable", "UndefinedSymbol"] ->
+				SyntaxExpr[d, "UndefinedSymbol"]
 		]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
+			SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Limit[Limit[a b c d, c -> d], a -> b]"
@@ -209,15 +209,15 @@ Test[
 	,
 	Limit[
 		Limit[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"]
 			,
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
-				syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
+				SyntaxExpr[b, "UndefinedSymbol"]
 		]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
+			SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Limit[Limit[a b, a -> b], a -> b]"
@@ -233,18 +233,18 @@ Test[
 	,
 	Table[
 		Solve[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[c, "UndefinedSymbol"] *
-			syntaxExpr[d, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[c, "UndefinedSymbol"] *
+			SyntaxExpr[d, "UndefinedSymbol"]
 			,
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 		]
 		,
 		{
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"],
-			syntaxExpr[d, "UndefinedSymbol"]
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"],
+			SyntaxExpr[d, "UndefinedSymbol"]
 		}
 	] // MakeBoxes
 	,
@@ -257,19 +257,19 @@ Test[
 	,
 	Limit[
 		Plot[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] *
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] *
+			SyntaxExpr[c, "UndefinedSymbol"]
 			,
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
-			syntaxExpr[b, "UndefinedSymbol"],
-			syntaxExpr[c, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[c, "UndefinedSymbol"]
 		}
 		]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] ->
+			SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Limit[Plot[a b c, {a, b, c}], a -> b]"

--- a/SyntaxAnnotations/Tests/Integration/MixedNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/MixedNested.mt
@@ -22,12 +22,12 @@ Test[
 	Solve[With[{b}, a b], a] // MakeBoxes // AnnotateSyntax
 	,
 	Solve[
-		With[{syntaxExpr[b, "LocalVariable", "UndefinedSymbol"]},
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "LocalVariable", "UndefinedSymbol"]
+		With[{SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"]},
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"]
 		]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Solve[With[{b}, a b], a]"
@@ -40,17 +40,17 @@ Test[
 	Table[
 		Module[
 			{
-				syntaxExpr[a,
+				SyntaxExpr[a,
 					"LocalVariable", "FunctionLocalVariable", "UndefinedSymbol"
 				]
 			}
 			,
-			syntaxExpr[a,
+			SyntaxExpr[a,
 				"LocalVariable", "FunctionLocalVariable", "UndefinedSymbol"
 			]
 		]
 		,
-		{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"], 0, 1}
+		{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"], 0, 1}
 	] // MakeBoxes
 	,
 	TestID -> "Table[Module[{a}, a], {a, 0, 1}]"
@@ -65,13 +65,13 @@ Test[
 	Block[{a}, Plot[a b, {b, 0, 1}]] // MakeBoxes // AnnotateSyntax
 	,
 	Block[
-		{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]}
+		{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]}
 		,
 		Plot[
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 			,
-			{syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"], 0, 1}
+			{SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"], 0, 1}
 		]
 	] // MakeBoxes
 	,
@@ -83,17 +83,17 @@ Test[
 	With[{a}, Limit[a, a -> a]] // MakeBoxes // AnnotateSyntax
 	,
 	With[
-		{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]}
+		{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]}
 		,
 		Limit[
-			syntaxExpr[a,
+			SyntaxExpr[a,
 				"FunctionLocalVariable", "LocalVariable", "UndefinedSymbol"
 			]
 			,
-			syntaxExpr[a,
+			SyntaxExpr[a,
 				"FunctionLocalVariable", "LocalVariable", "UndefinedSymbol"
 			] ->
-				syntaxExpr[a,
+				SyntaxExpr[a,
 					"FunctionLocalVariable", "LocalVariable", "UndefinedSymbol"
 				]
 		]
@@ -111,12 +111,12 @@ Test[
 	Solve[a b_ -> a b, a] // MakeBoxes // AnnotateSyntax
 	,
 	Solve[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b_, "PatternVariable"] ->
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b_, "PatternVariable"] ->
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Solve[a b_ -> a b, a]"
@@ -127,10 +127,10 @@ Test[
 	Table[a_ = a, {a, 0, 1}] // MakeBoxes // AnnotateSyntax
 	,
 	Table[
-		syntaxExpr[a_, "PatternVariable", "FunctionLocalVariable"] =
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable", "FunctionLocalVariable"] =
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 		,
-		{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"], 0, 1}
+		{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"], 0, 1}
 	] // MakeBoxes
 	,
 	TestID -> "Table[a_ = a, {a, 0, 1}]"
@@ -146,10 +146,10 @@ Test[
 	,
 	(
 		Plot[
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b_, "PatternVariable"],
-			{syntaxExpr[a, "UndefinedSymbol"], 0, 1}
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b_, "PatternVariable"],
+			{SyntaxExpr[a, "UndefinedSymbol"], 0, 1}
 		] ^=
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
 	) // MakeBoxes
 	,
 	TestID -> "Plot[a b_, {a, 0, 1}] ^= a b"
@@ -160,12 +160,12 @@ Test[
 	(a /: Limit[a, a -> a] = a) // MakeBoxes // AnnotateSyntax
 	,
 	(
-		syntaxExpr[a, "UndefinedSymbol"] /:
+		SyntaxExpr[a, "UndefinedSymbol"] /:
 			Limit[
-				syntaxExpr[a, "UndefinedSymbol"],
-				syntaxExpr[a, "UndefinedSymbol"] ->
-					syntaxExpr[a, "UndefinedSymbol"]
-			] = syntaxExpr[a, "UndefinedSymbol"]
+				SyntaxExpr[a, "UndefinedSymbol"],
+				SyntaxExpr[a, "UndefinedSymbol"] ->
+					SyntaxExpr[a, "UndefinedSymbol"]
+			] = SyntaxExpr[a, "UndefinedSymbol"]
 	) // MakeBoxes
 	,
 	TestID -> "a /: Limit[a, a -> a] = a"
@@ -176,11 +176,11 @@ Test[
 	(a_ /: Limit[a_, a_ -> a_] = a_) // MakeBoxes // AnnotateSyntax
 	,
 	(
-		syntaxExpr[a_, "PatternVariable"] /:
+		SyntaxExpr[a_, "PatternVariable"] /:
 			Limit[
-				syntaxExpr[a_, "PatternVariable"],
-				syntaxExpr[a_, "PatternVariable"] ->
-					syntaxExpr[a_, "PatternVariable"]
+				SyntaxExpr[a_, "PatternVariable"],
+				SyntaxExpr[a_, "PatternVariable"] ->
+					SyntaxExpr[a_, "PatternVariable"]
 			] = a_
 	) // MakeBoxes
 	,
@@ -196,13 +196,13 @@ Test[
 	Solve[a b_ :> a b b_, a] // MakeBoxes // AnnotateSyntax
 	,
 	Solve[
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b_, "PatternVariable"] :>
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "PatternVariable", "UndefinedSymbol"] *
-			syntaxExpr[b_, "LocalScopeConflict"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b_, "PatternVariable"] :>
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b_, "LocalScopeConflict"]
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Solve[a b_ :> a b b_, a]"
@@ -213,13 +213,13 @@ Test[
 	Table[a_ := a a_, {a, 0, 1}] // MakeBoxes // AnnotateSyntax
 	,
 	Table[
-		syntaxExpr[a_, "PatternVariable", "FunctionLocalVariable"] :=
-			syntaxExpr[a,
+		SyntaxExpr[a_, "PatternVariable", "FunctionLocalVariable"] :=
+			SyntaxExpr[a,
 				"PatternVariable", "FunctionLocalVariable", "UndefinedSymbol"
 			] *
-			syntaxExpr[a_, "LocalScopeConflict", "FunctionLocalVariable"]
+			SyntaxExpr[a_, "LocalScopeConflict", "FunctionLocalVariable"]
 		,
-		{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"], 0, 1}
+		{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"], 0, 1}
 	] // MakeBoxes
 	,
 	TestID -> "Table[a_ := a a_, {a, 0, 1}]"
@@ -234,15 +234,15 @@ Test[
 	(a_ ^:= Plot[a a_ b b_, {b, 0, 1}]) // MakeBoxes // AnnotateSyntax
 	,
 	(
-		syntaxExpr[a_, "PatternVariable"] ^:=
+		SyntaxExpr[a_, "PatternVariable"] ^:=
 			Plot[
-				syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-				syntaxExpr[a_, "LocalScopeConflict"] *
-				syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"] *
-				syntaxExpr[b_, "FunctionLocalVariable"]
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+				SyntaxExpr[a_, "LocalScopeConflict"] *
+				SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"] *
+				SyntaxExpr[b_, "FunctionLocalVariable"]
 				,
 				{
-					syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"],
+					SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"],
 					0,
 					1
 				}
@@ -257,22 +257,22 @@ Test[
 	(a /: a_ := Limit[a a_, a -> a]) // MakeBoxes // AnnotateSyntax
 	,
 	(
-		syntaxExpr[a, "UndefinedSymbol"] /:
-			syntaxExpr[a_, "PatternVariable"] :=
+		SyntaxExpr[a, "UndefinedSymbol"] /:
+			SyntaxExpr[a_, "PatternVariable"] :=
 				Limit[
-					syntaxExpr[a,
+					SyntaxExpr[a,
 						"PatternVariable", "FunctionLocalVariable",
 						"UndefinedSymbol"
 					] *
-					syntaxExpr[a_,
+					SyntaxExpr[a_,
 						"LocalScopeConflict", "FunctionLocalVariable"
 					]
 					,
-					syntaxExpr[a,
+					SyntaxExpr[a,
 						"PatternVariable", "FunctionLocalVariable",
 						"UndefinedSymbol"
 					] ->
-						syntaxExpr[a,
+						SyntaxExpr[a,
 							"PatternVariable", "FunctionLocalVariable",
 							"UndefinedSymbol"
 						]
@@ -290,11 +290,11 @@ Test[
 Test[
 	With[{a}, a b_ -> a b] // MakeBoxes // AnnotateSyntax
 	,
-	With[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		 syntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
-		 syntaxExpr[b_, "PatternVariable"] ->
-		 	syntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"]
+	With[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		 SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+		 SyntaxExpr[b_, "PatternVariable"] ->
+		 	SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "With[{a}, a b_ -> a b]"
@@ -304,9 +304,9 @@ Test[
 Test[
 	Block[{a}, a_ = a] // MakeBoxes // AnnotateSyntax
 	,
-	Block[{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
-		 syntaxExpr[a_, "FunctionLocalVariable", "PatternVariable"] =
-		 	syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+	Block[{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
+		 SyntaxExpr[a_, "FunctionLocalVariable", "PatternVariable"] =
+		 	SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Block[{a}, a_ = a]"
@@ -322,10 +322,10 @@ Test[
 	,
 	(
 		With[
-			{syntaxExpr[a, "UndefinedSymbol"]},
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b_, "PatternVariable"]
+			{SyntaxExpr[a, "UndefinedSymbol"]},
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b_, "PatternVariable"]
 		] ^=
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
 	) // MakeBoxes
 	,
 	TestID -> "With[{a}, a b_] ^= a b"
@@ -336,10 +336,10 @@ Test[
 	(a /: Module[{a}, a] = a) // MakeBoxes // AnnotateSyntax
 	,
 	(
-		syntaxExpr[a, "UndefinedSymbol"] /:
-			Module[{syntaxExpr[a, "UndefinedSymbol"]},
-				syntaxExpr[a, "UndefinedSymbol"]
-			] = syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] /:
+			Module[{SyntaxExpr[a, "UndefinedSymbol"]},
+				SyntaxExpr[a, "UndefinedSymbol"]
+			] = SyntaxExpr[a, "UndefinedSymbol"]
 	) // MakeBoxes
 	,
 	TestID -> "a /: Module[{a}, a] = a"
@@ -350,9 +350,9 @@ Test[
 	(a_ /: Block[{a_}, a_] = a_) // MakeBoxes // AnnotateSyntax
 	,
 	(
-		syntaxExpr[a_, "PatternVariable"] /:
-			Block[{syntaxExpr[a_, "PatternVariable"]},
-				syntaxExpr[a_, "PatternVariable"]
+		SyntaxExpr[a_, "PatternVariable"] /:
+			Block[{SyntaxExpr[a_, "PatternVariable"]},
+				SyntaxExpr[a_, "PatternVariable"]
 			] = a_
 	) // MakeBoxes
 	,
@@ -367,12 +367,12 @@ Test[
 Test[
 	Block[{a}, a b_ :> a b b_] // MakeBoxes // AnnotateSyntax
 	,
-	Block[{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b_, "PatternVariable"] :>
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "PatternVariable", "UndefinedSymbol"] *
-			syntaxExpr[b_, "LocalScopeConflict"]
+	Block[{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b_, "PatternVariable"] :>
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b_, "LocalScopeConflict"]
 	] // MakeBoxes
 	,
 	TestID -> "Block[{a}, a b_ :> a b b_]"
@@ -382,12 +382,12 @@ Test[
 Test[
 	Module[{a}, a_ := a a_] // MakeBoxes // AnnotateSyntax
 	,
-	Module[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[a_, "LocalVariable", "PatternVariable"] :=
-			syntaxExpr[a,
+	Module[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a_, "LocalVariable", "PatternVariable"] :=
+			SyntaxExpr[a,
 				"LocalVariable", "PatternVariable", "UndefinedSymbol"
 			] *
-			syntaxExpr[a_, "LocalVariable", "LocalScopeConflict"]
+			SyntaxExpr[a_, "LocalVariable", "LocalScopeConflict"]
 	] // MakeBoxes
 	,
 	TestID -> "Module[{a}, a_ := a a_]"
@@ -402,12 +402,12 @@ Test[
 	(a_ ^:= With[{b}, a a_ b b_]) // MakeBoxes // AnnotateSyntax
 	,
 	(
-		syntaxExpr[a_, "PatternVariable"] ^:=
-			With[{syntaxExpr[b, "LocalVariable", "UndefinedSymbol"]},
-				syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-				syntaxExpr[a_, "LocalScopeConflict"] *
-				syntaxExpr[b, "LocalVariable", "UndefinedSymbol"] *
-				syntaxExpr[b_, "LocalVariable"]
+		SyntaxExpr[a_, "PatternVariable"] ^:=
+			With[{SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"]},
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+				SyntaxExpr[a_, "LocalScopeConflict"] *
+				SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"] *
+				SyntaxExpr[b_, "LocalVariable"]
 			]
 	) // MakeBoxes
 	,
@@ -419,21 +419,21 @@ Test[
 	(a /: a_ := Block[{a}, a a_]) // MakeBoxes // AnnotateSyntax
 	,
 	(
-		syntaxExpr[a, "UndefinedSymbol"] /:
-			syntaxExpr[a_, "PatternVariable"] :=
+		SyntaxExpr[a, "UndefinedSymbol"] /:
+			SyntaxExpr[a_, "PatternVariable"] :=
 				Block[
 					{
-						syntaxExpr[a,
+						SyntaxExpr[a,
 							"LocalScopeConflict", "FunctionLocalVariable",
 							"UndefinedSymbol"
 						]
 					}
 					,
-					syntaxExpr[a,
+					SyntaxExpr[a,
 						"LocalScopeConflict", "FunctionLocalVariable",
 						"UndefinedSymbol"
 					] *
-					syntaxExpr[a_,
+					SyntaxExpr[a_,
 						"LocalScopeConflict", "FunctionLocalVariable"
 					]
 				]

--- a/SyntaxAnnotations/Tests/Integration/Patterns.mt
+++ b/SyntaxAnnotations/Tests/Integration/Patterns.mt
@@ -22,7 +22,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a -> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] -> syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] -> SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a -> a"
@@ -33,7 +33,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ -> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] -> syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] -> SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ -> a"
@@ -44,7 +44,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a__ -> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a__, "PatternVariable"] -> syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a__, "PatternVariable"] -> SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a__ -> a"
@@ -55,7 +55,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a___ -> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a___, "PatternVariable"] -> syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a___, "PatternVariable"] -> SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a___ -> a"
@@ -65,7 +65,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[_a -> a]
 	,
-	MakeBoxes[_a -> syntaxExpr[a, "UndefinedSymbol"]]
+	MakeBoxes[_a -> SyntaxExpr[a, "UndefinedSymbol"]]
 	,
 	TestID -> "_a -> a"
 ]
@@ -74,7 +74,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[__a -> a]
 	,
-	MakeBoxes[__a -> syntaxExpr[a, "UndefinedSymbol"]]
+	MakeBoxes[__a -> SyntaxExpr[a, "UndefinedSymbol"]]
 	,
 	TestID -> "__a -> a"
 ]
@@ -83,7 +83,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[___a -> a]
 	,
-	MakeBoxes[___a -> syntaxExpr[a, "UndefinedSymbol"]]
+	MakeBoxes[___a -> SyntaxExpr[a, "UndefinedSymbol"]]
 	,
 	TestID -> "___a -> a"
 ]
@@ -93,8 +93,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_b -> a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_b, "PatternVariable"] ->
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a_b, "PatternVariable"] ->
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_b -> a b"
@@ -104,7 +104,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[a -> a_]
 	,
-	MakeBoxes[syntaxExpr[a, "UndefinedSymbol"] -> a_]
+	MakeBoxes[SyntaxExpr[a, "UndefinedSymbol"] -> a_]
 	,
 	TestID -> "a -> a_"
 ]
@@ -114,7 +114,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ \[Rule] a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] -> syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] -> SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ \\[Rule] a"
@@ -125,8 +125,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ b_ -> a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[b_, "PatternVariable"] ->
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[b_, "PatternVariable"] ->
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ b_ -> a b"
@@ -137,8 +137,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ a -> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[a, "UndefinedSymbol"] ->
-			syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[a, "UndefinedSymbol"] ->
+			SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ a -> a"
@@ -153,7 +153,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a = a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] = syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] = SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a = a"
@@ -164,7 +164,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ = a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] = syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] = SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ = a"
@@ -174,7 +174,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[a = a_]
 	,
-	MakeBoxes[syntaxExpr[a, "UndefinedSymbol"] = a_]
+	MakeBoxes[SyntaxExpr[a, "UndefinedSymbol"] = a_]
 	,
 	TestID -> "a = a_"
 ]
@@ -184,8 +184,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ b_ = a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[b_, "PatternVariable"] =
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[b_, "PatternVariable"] =
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ b_ = a b"
@@ -200,7 +200,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a ^= a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] ^= syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] ^= SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a ^= a"
@@ -211,7 +211,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ ^= a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] ^= syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] ^= SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ ^= a"
@@ -221,7 +221,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[a ^= a_]
 	,
-	MakeBoxes[syntaxExpr[a, "UndefinedSymbol"] ^= a_]
+	MakeBoxes[SyntaxExpr[a, "UndefinedSymbol"] ^= a_]
 	,
 	TestID -> "a ^= a_"
 ]
@@ -231,8 +231,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ b_ ^= a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[b_, "PatternVariable"] ^=
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[b_, "PatternVariable"] ^=
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ b_ ^= a b"
@@ -247,8 +247,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a = a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /: syntaxExpr[a, "UndefinedSymbol"] =
-			syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] /: SyntaxExpr[a, "UndefinedSymbol"] =
+			SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a /: a = a"
@@ -259,8 +259,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ /: a = a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] /: syntaxExpr[a, "UndefinedSymbol"] =
-			syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] /: SyntaxExpr[a, "UndefinedSymbol"] =
+			SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ /: a = a"
@@ -271,8 +271,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a_ = a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /: syntaxExpr[a_, "PatternVariable"] =
-			syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] /: SyntaxExpr[a_, "PatternVariable"] =
+			SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a /: a_ = a"
@@ -283,7 +283,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a = a_]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /: syntaxExpr[a, "UndefinedSymbol"] =
+		SyntaxExpr[a, "UndefinedSymbol"] /: SyntaxExpr[a, "UndefinedSymbol"] =
 			a_
 	]
 	,
@@ -295,10 +295,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ b_ /: a b = a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[b_, "PatternVariable"] /:
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"] =
-				syntaxExpr[a, "UndefinedSymbol"] *
-				syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[b_, "PatternVariable"] /:
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"] =
+				SyntaxExpr[a, "UndefinedSymbol"] *
+				SyntaxExpr[b, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ b_ /: a b = a b"
@@ -309,11 +309,11 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a b /: a_ b_ = a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"] /:
-			syntaxExpr[a_, "PatternVariable"] *
-			syntaxExpr[b_, "PatternVariable"] =
-				syntaxExpr[a, "UndefinedSymbol"] *
-				syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"] /:
+			SyntaxExpr[a_, "PatternVariable"] *
+			SyntaxExpr[b_, "PatternVariable"] =
+				SyntaxExpr[a, "UndefinedSymbol"] *
+				SyntaxExpr[b, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a b /: a_ b_ = a b"
@@ -324,8 +324,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a b /: a b = a_ b_]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"] /:
-			syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"] =
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"] /:
+			SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"] =
 				a_ b_
 	]
 	,

--- a/SyntaxAnnotations/Tests/Integration/PatternsDelayed.mt
+++ b/SyntaxAnnotations/Tests/Integration/PatternsDelayed.mt
@@ -24,7 +24,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a :> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] :> syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] :> SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a :> a"
@@ -35,8 +35,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ :> a"
@@ -47,8 +47,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a__ :> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a__, "PatternVariable"] :>
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a__, "PatternVariable"] :>
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a__ :> a"
@@ -59,8 +59,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a___ :> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a___, "PatternVariable"] :>
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a___, "PatternVariable"] :>
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a___ :> a"
@@ -70,7 +70,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[_a :> a]
 	,
-	MakeBoxes[_a :> syntaxExpr[a, "UndefinedSymbol"]]
+	MakeBoxes[_a :> SyntaxExpr[a, "UndefinedSymbol"]]
 	,
 	TestID -> "_a :> a"
 ]
@@ -79,7 +79,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[__a :> a]
 	,
-	MakeBoxes[__a :> syntaxExpr[a, "UndefinedSymbol"]]
+	MakeBoxes[__a :> SyntaxExpr[a, "UndefinedSymbol"]]
 	,
 	TestID -> "__a :> a"
 ]
@@ -88,7 +88,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[___a :> a]
 	,
-	MakeBoxes[___a :> syntaxExpr[a, "UndefinedSymbol"]]
+	MakeBoxes[___a :> SyntaxExpr[a, "UndefinedSymbol"]]
 	,
 	TestID -> "___a :> a"
 ]
@@ -98,9 +98,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_b :> a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_b, "PatternVariable"] :>
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a_b, "PatternVariable"] :>
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_b :> a b"
@@ -110,7 +110,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[a :> a_]
 	,
-	MakeBoxes[syntaxExpr[a, "UndefinedSymbol"] :> a_]
+	MakeBoxes[SyntaxExpr[a, "UndefinedSymbol"] :> a_]
 	,
 	TestID -> "a :> a_"
 ]
@@ -120,8 +120,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> a_]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[a_, "LocalScopeConflict"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[a_, "LocalScopeConflict"]
 	]
 	,
 	TestID -> "a_ :> a_"
@@ -132,8 +132,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> a__]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[a__, "LocalScopeConflict"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[a__, "LocalScopeConflict"]
 	]
 	,
 	TestID -> "a_ :> a__"
@@ -144,8 +144,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> a___]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[a___, "LocalScopeConflict"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[a___, "LocalScopeConflict"]
 	]
 	,
 	TestID -> "a_ :> a___"
@@ -156,8 +156,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> _a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[_a, "PatternVariable"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[_a, "PatternVariable"]
 	]
 	,
 	TestID -> "a_ :> _a"
@@ -168,8 +168,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> __a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[__a, "PatternVariable"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[__a, "PatternVariable"]
 	]
 	,
 	TestID -> "a_ :> __a"
@@ -180,8 +180,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> ___a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[___a, "PatternVariable"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[___a, "PatternVariable"]
 	]
 	,
 	TestID -> "a_ :> ___a"
@@ -192,8 +192,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ \[RuleDelayed] a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ \\[RuleDelayed] a"
@@ -204,8 +204,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> a_b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :>
-			syntaxExpr[a_b, "LocalScopeConflict"]
+		SyntaxExpr[a_, "PatternVariable"] :>
+			SyntaxExpr[a_b, "LocalScopeConflict"]
 	]
 	,
 	TestID -> "a_ :> a_b"
@@ -215,7 +215,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> b_a]
 	,
-	MakeBoxes[syntaxExpr[a_, "PatternVariable"] :> b_a]
+	MakeBoxes[SyntaxExpr[a_, "PatternVariable"] :> b_a]
 	,
 	TestID -> "a_ :> b_a"
 ]
@@ -225,9 +225,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ b_ :> a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[b_, "PatternVariable"] :>
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[b_, "PatternVariable"] :>
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ b_ :> a b"
@@ -238,8 +238,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ a :> a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[a, "UndefinedSymbol"] :>
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[a, "UndefinedSymbol"] :>
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ a :> a"
@@ -254,7 +254,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a := a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] := syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] := SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a := a"
@@ -265,8 +265,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ := a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] :=
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] :=
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ := a"
@@ -276,7 +276,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[a := a_]
 	,
-	MakeBoxes[syntaxExpr[a, "UndefinedSymbol"] := a_]
+	MakeBoxes[SyntaxExpr[a, "UndefinedSymbol"] := a_]
 	,
 	TestID -> "a := a_"
 ]
@@ -286,9 +286,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ b_ := a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[b_, "PatternVariable"] :=
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[b_, "PatternVariable"] :=
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ b_ := a b"
@@ -303,7 +303,7 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a ^:= a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] ^:= syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] ^:= SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a ^:= a"
@@ -314,8 +314,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ ^:= a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] ^:=
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] ^:=
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ ^:= a"
@@ -325,7 +325,7 @@ Test[
 Test[
 	AnnotateSyntax @ MakeBoxes[a ^:= a_]
 	,
-	MakeBoxes[syntaxExpr[a, "UndefinedSymbol"] ^:= a_]
+	MakeBoxes[SyntaxExpr[a, "UndefinedSymbol"] ^:= a_]
 	,
 	TestID -> "a ^:= a_"
 ]
@@ -335,9 +335,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ b_ ^:= a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[b_, "PatternVariable"] ^:=
-			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[b_, "PatternVariable"] ^:=
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ b_ ^:= a b"
@@ -352,8 +352,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a := a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /: syntaxExpr[a, "UndefinedSymbol"] :=
-			syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] /: SyntaxExpr[a, "UndefinedSymbol"] :=
+			SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a /: a := a"
@@ -364,9 +364,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ /: a := a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] /:
-			syntaxExpr[a, "UndefinedSymbol"] :=
-				syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] /:
+			SyntaxExpr[a, "UndefinedSymbol"] :=
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ /: a := a"
@@ -377,9 +377,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a_ := a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /:
-			syntaxExpr[a_, "PatternVariable"] :=
-				syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] /:
+			SyntaxExpr[a_, "PatternVariable"] :=
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a /: a_ := a"
@@ -390,8 +390,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a := a_]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /:
-			syntaxExpr[a, "UndefinedSymbol"] := a_
+		SyntaxExpr[a, "UndefinedSymbol"] /:
+			SyntaxExpr[a, "UndefinedSymbol"] := a_
 	]
 	,
 	TestID -> "a /: a := a_"
@@ -402,9 +402,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ /: a_ := a]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] /:
-			syntaxExpr[a_, "PatternVariable"] :=
-				syntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] /:
+			SyntaxExpr[a_, "PatternVariable"] :=
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ /: a_ := a"
@@ -415,9 +415,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ /: a := a_]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] /:
-			syntaxExpr[a, "UndefinedSymbol"] :=
-				syntaxExpr[a_, "LocalScopeConflict"]
+		SyntaxExpr[a_, "PatternVariable"] /:
+			SyntaxExpr[a, "UndefinedSymbol"] :=
+				SyntaxExpr[a_, "LocalScopeConflict"]
 	]
 	,
 	TestID -> "a_ /: a := a_"
@@ -428,9 +428,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a_ := a_]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /:
-			syntaxExpr[a_, "PatternVariable"] :=
-				syntaxExpr[a_, "LocalScopeConflict"]
+		SyntaxExpr[a, "UndefinedSymbol"] /:
+			SyntaxExpr[a_, "PatternVariable"] :=
+				SyntaxExpr[a_, "LocalScopeConflict"]
 	]
 	,
 	TestID -> "a /: a_ := a_"
@@ -441,9 +441,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ /: a_ := a_]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] /:
-			syntaxExpr[a_, "PatternVariable"] :=
-				syntaxExpr[a_, "LocalScopeConflict"]
+		SyntaxExpr[a_, "PatternVariable"] /:
+			SyntaxExpr[a_, "PatternVariable"] :=
+				SyntaxExpr[a_, "LocalScopeConflict"]
 	]
 	,
 	TestID -> "a_ /: a_ := a_"
@@ -454,11 +454,11 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ b_ /: a b := a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a_, "PatternVariable"] syntaxExpr[b_, "PatternVariable"] /:
-			syntaxExpr[a, "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] :=
-				syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-				syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a_, "PatternVariable"] SyntaxExpr[b_, "PatternVariable"] /:
+			SyntaxExpr[a, "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] :=
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+				SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a_ b_ /: a b := a b"
@@ -469,11 +469,11 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a b /: a_ b_ := a b]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"] /:
-			syntaxExpr[a_, "PatternVariable"] *
-			syntaxExpr[b_, "PatternVariable"] :=
-				syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-				syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"] /:
+			SyntaxExpr[a_, "PatternVariable"] *
+			SyntaxExpr[b_, "PatternVariable"] :=
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+				SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a b /: a_ b_ := a b"
@@ -484,9 +484,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a b /: a b := a_ b_]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] syntaxExpr[b, "UndefinedSymbol"] /:
-			syntaxExpr[a, "UndefinedSymbol"] *
-			syntaxExpr[b, "UndefinedSymbol"] :=
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"] /:
+			SyntaxExpr[a, "UndefinedSymbol"] *
+			SyntaxExpr[b, "UndefinedSymbol"] :=
 				a_ b_
 	]
 	,

--- a/SyntaxAnnotations/Tests/Integration/PatternsDelayedNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/PatternsDelayedNested.mt
@@ -24,10 +24,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> (b_ :> a b)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] :> (
-		 	syntaxExpr[b_, "PatternVariable"] :>
-		 		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-		 		syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		 SyntaxExpr[a_, "PatternVariable"] :> (
+		 	SyntaxExpr[b_, "PatternVariable"] :>
+		 		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		 		SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 		 )
 	]
 	,
@@ -39,9 +39,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> (a_ :> a)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] :> (
-		 	syntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :>
-		 		syntaxExpr[a,
+		 SyntaxExpr[a_, "PatternVariable"] :> (
+		 	SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :>
+		 		SyntaxExpr[a,
 		 			"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
 		 		]
 		 )
@@ -55,9 +55,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> (a :> a_)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] :> (
-		 	syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] :>
-		 		syntaxExpr[a_, "LocalScopeConflict"]
+		 SyntaxExpr[a_, "PatternVariable"] :> (
+		 	SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] :>
+		 		SyntaxExpr[a_, "LocalScopeConflict"]
 		 )
 	]
 	,
@@ -73,10 +73,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ := (b_ := a b)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] := (
-		 	syntaxExpr[b_, "PatternVariable"] :=
-		 		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-		 		syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		 SyntaxExpr[a_, "PatternVariable"] := (
+		 	SyntaxExpr[b_, "PatternVariable"] :=
+		 		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		 		SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 		 )
 	]
 	,
@@ -88,9 +88,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ := (a_ := a)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] := (
-		 	syntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :=
-		 		syntaxExpr[a,
+		 SyntaxExpr[a_, "PatternVariable"] := (
+		 	SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :=
+		 		SyntaxExpr[a,
 		 			"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
 		 		]
 		 )
@@ -104,9 +104,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ := (a := a_)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] := (
-		 	syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] :=
-		 		syntaxExpr[a_, "LocalScopeConflict"]
+		 SyntaxExpr[a_, "PatternVariable"] := (
+		 	SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] :=
+		 		SyntaxExpr[a_, "LocalScopeConflict"]
 		 )
 	]
 	,
@@ -122,10 +122,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ ^:= (b_ ^:= a b)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] ^:= (
-		 	syntaxExpr[b_, "PatternVariable"] ^:=
-		 		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-		 		syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		 SyntaxExpr[a_, "PatternVariable"] ^:= (
+		 	SyntaxExpr[b_, "PatternVariable"] ^:=
+		 		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		 		SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 		 )
 	]
 	,
@@ -137,9 +137,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ ^:= (a_ ^:= a)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] ^:= (
-		 	syntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] ^:=
-		 		syntaxExpr[a,
+		 SyntaxExpr[a_, "PatternVariable"] ^:= (
+		 	SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] ^:=
+		 		SyntaxExpr[a,
 		 			"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
 		 		]
 		 )
@@ -153,9 +153,9 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ ^:= (a ^:= a_)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] ^:= (
-		 	syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] ^:=
-		 		syntaxExpr[a_, "LocalScopeConflict"]
+		 SyntaxExpr[a_, "PatternVariable"] ^:= (
+		 	SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] ^:=
+		 		SyntaxExpr[a_, "LocalScopeConflict"]
 		 )
 	]
 	,
@@ -171,11 +171,11 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ /: a := (b_ := a b)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] /:
-		 	syntaxExpr[a, "UndefinedSymbol"] := (
-		 		syntaxExpr[b_, "PatternVariable"] :=
-		 			syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
-		 			syntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+		 SyntaxExpr[a_, "PatternVariable"] /:
+		 	SyntaxExpr[a, "UndefinedSymbol"] := (
+		 		SyntaxExpr[b_, "PatternVariable"] :=
+		 			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		 			SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
 		 	)
 	]
 	,
@@ -187,10 +187,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ /: a := (a_ := a)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] /:
-		 	syntaxExpr[a, "UndefinedSymbol"] := (
-		 		syntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :=
-		 			syntaxExpr[a,
+		 SyntaxExpr[a_, "PatternVariable"] /:
+		 	SyntaxExpr[a, "UndefinedSymbol"] := (
+		 		SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :=
+		 			SyntaxExpr[a,
 		 				"LocalScopeConflict", "PatternVariable",
 		 				"UndefinedSymbol"
 		 			]
@@ -205,10 +205,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a_ /: a := (a := a_)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a_, "PatternVariable"] /:
-		 	syntaxExpr[a, "UndefinedSymbol"] := (
-		 		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] :=
-		 			syntaxExpr[a_, "LocalScopeConflict"]
+		 SyntaxExpr[a_, "PatternVariable"] /:
+		 	SyntaxExpr[a, "UndefinedSymbol"] := (
+		 		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] :=
+		 			SyntaxExpr[a_, "LocalScopeConflict"]
 		 	)
 	]
 	,
@@ -220,10 +220,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a_ := (a_ := a)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a, "UndefinedSymbol"] /:
-		 	syntaxExpr[a_, "PatternVariable"] := (
-		 		syntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :=
-		 			syntaxExpr[a,
+		 SyntaxExpr[a, "UndefinedSymbol"] /:
+		 	SyntaxExpr[a_, "PatternVariable"] := (
+		 		SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :=
+		 			SyntaxExpr[a,
 		 				"LocalScopeConflict", "PatternVariable",
 		 				"UndefinedSymbol"
 		 			]
@@ -238,10 +238,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a_ := (a := a_)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a, "UndefinedSymbol"] /:
-		 	syntaxExpr[a_, "PatternVariable"] := (
-		 		syntaxExpr[a, "PatternVariable", "UndefinedSymbol"] :=
-		 			syntaxExpr[a_, "LocalScopeConflict"]
+		 SyntaxExpr[a, "UndefinedSymbol"] /:
+		 	SyntaxExpr[a_, "PatternVariable"] := (
+		 		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] :=
+		 			SyntaxExpr[a_, "LocalScopeConflict"]
 		 	)
 	]
 	,

--- a/SyntaxAnnotations/Tests/Integration/PatternsNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/PatternsNested.mt
@@ -23,10 +23,10 @@ Test[
 	,
 	MakeBoxes[
 		(
-			syntaxExpr[a_, "PatternVariable"] ->
-				syntaxExpr[a_, "PatternVariable"]
+			SyntaxExpr[a_, "PatternVariable"] ->
+				SyntaxExpr[a_, "PatternVariable"]
 		) ->
-			syntaxExpr[a, "UndefinedSymbol"]
+			SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "(a_ -> a_) -> a"
@@ -37,8 +37,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a -> (a_ -> a_)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a, "UndefinedSymbol"] ->
-		 	(syntaxExpr[a_, "PatternVariable"] -> a_)
+		 SyntaxExpr[a, "UndefinedSymbol"] ->
+		 	(SyntaxExpr[a_, "PatternVariable"] -> a_)
 	]
 	,
 	TestID -> "a -> (a_ -> a_)"
@@ -54,10 +54,10 @@ Test[
 	,
 	MakeBoxes[
 		(
-			syntaxExpr[a_, "PatternVariable"] =
-				syntaxExpr[a_, "PatternVariable"]
+			SyntaxExpr[a_, "PatternVariable"] =
+				SyntaxExpr[a_, "PatternVariable"]
 		) =
-			syntaxExpr[a, "UndefinedSymbol"]
+			SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "(a_ = a_) = a"
@@ -68,8 +68,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a = (a_ = a_)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a, "UndefinedSymbol"] =
-		 	(syntaxExpr[a_, "PatternVariable"] = a_)
+		 SyntaxExpr[a, "UndefinedSymbol"] =
+		 	(SyntaxExpr[a_, "PatternVariable"] = a_)
 	]
 	,
 	TestID -> "a = (a_ = a_)"
@@ -85,10 +85,10 @@ Test[
 	,
 	MakeBoxes[
 		(
-			syntaxExpr[a_, "PatternVariable"] ^=
-				syntaxExpr[a_, "PatternVariable"]
+			SyntaxExpr[a_, "PatternVariable"] ^=
+				SyntaxExpr[a_, "PatternVariable"]
 		) ^=
-			syntaxExpr[a, "UndefinedSymbol"]
+			SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "(a_ ^= a_) = a"
@@ -99,8 +99,8 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a ^= (a_ ^= a_)]
 	,
 	MakeBoxes[
-		 syntaxExpr[a, "UndefinedSymbol"] ^=
-		 	(syntaxExpr[a_, "PatternVariable"] ^= a_)
+		 SyntaxExpr[a, "UndefinedSymbol"] ^=
+		 	(SyntaxExpr[a_, "PatternVariable"] ^= a_)
 	]
 	,
 	TestID -> "a ^= (a_ ^= a_)"
@@ -116,11 +116,11 @@ Test[
 	,
 	MakeBoxes[
 		(
-			syntaxExpr[a_, "PatternVariable"] /:
-				syntaxExpr[a_, "PatternVariable"] =
-					syntaxExpr[a_, "PatternVariable"]
+			SyntaxExpr[a_, "PatternVariable"] /:
+				SyntaxExpr[a_, "PatternVariable"] =
+					SyntaxExpr[a_, "PatternVariable"]
 		) /:
-			syntaxExpr[a, "UndefinedSymbol"] = syntaxExpr[a, "UndefinedSymbol"]
+			SyntaxExpr[a, "UndefinedSymbol"] = SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "(a_ /: a_ = a_) /: a = a"
@@ -131,11 +131,11 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: (a_ /: a_ = a_) = a]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /: (
-			syntaxExpr[a_, "PatternVariable"] /:
-				syntaxExpr[a_, "PatternVariable"] =
-					syntaxExpr[a_, "PatternVariable"]
-		) = syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"] /: (
+			SyntaxExpr[a_, "PatternVariable"] /:
+				SyntaxExpr[a_, "PatternVariable"] =
+					SyntaxExpr[a_, "PatternVariable"]
+		) = SyntaxExpr[a, "UndefinedSymbol"]
 	]
 	,
 	TestID -> "a /: (a_ /: a_ = a_) = a"
@@ -146,10 +146,10 @@ Test[
 	AnnotateSyntax @ MakeBoxes[a /: a = (a_ /: a_ = a_)]
 	,
 	MakeBoxes[
-		syntaxExpr[a, "UndefinedSymbol"] /:
-			syntaxExpr[a, "UndefinedSymbol"] = (
-				syntaxExpr[a_, "PatternVariable"] /:
-					syntaxExpr[a_, "PatternVariable"] = a_
+		SyntaxExpr[a, "UndefinedSymbol"] /:
+			SyntaxExpr[a, "UndefinedSymbol"] = (
+				SyntaxExpr[a_, "PatternVariable"] /:
+					SyntaxExpr[a_, "PatternVariable"] = a_
 			)
 	]
 	,

--- a/SyntaxAnnotations/Tests/Integration/Scoping.mt
+++ b/SyntaxAnnotations/Tests/Integration/Scoping.mt
@@ -18,8 +18,8 @@ Test[
 	With[a, a] // MakeBoxes // AnnotateSyntax
 	,
 	With[
-		syntaxExpr[a, "UndefinedSymbol"],
-		syntaxExpr[a, "UndefinedSymbol"]
+		SyntaxExpr[a, "UndefinedSymbol"],
+		SyntaxExpr[a, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "With[a, a]"
@@ -29,8 +29,8 @@ Test[
 Test[
 	Module[{a}, a] // MakeBoxes // AnnotateSyntax
 	,
-	Module[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+	Module[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Module[{a}, a]"
@@ -40,8 +40,8 @@ Test[
 Test[
 	Block[{a}, a_] // MakeBoxes // AnnotateSyntax
 	,
-	Block[{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[a_, "FunctionLocalVariable"]
+	Block[{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a_, "FunctionLocalVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "Block[{a}, a_]"
@@ -51,8 +51,8 @@ Test[
 Test[
 	With[{a}, a__] // MakeBoxes // AnnotateSyntax
 	,
-	With[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[a__, "LocalVariable"]
+	With[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a__, "LocalVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "With[{a}, a__]"
@@ -62,8 +62,8 @@ Test[
 Test[
 	Module[{a}, a___] // MakeBoxes // AnnotateSyntax
 	,
-	Module[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[a___, "LocalVariable"]
+	Module[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a___, "LocalVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "Module[{a}, a___]"
@@ -73,8 +73,8 @@ Test[
 Test[
 	Block[{a}, _a] // MakeBoxes // AnnotateSyntax
 	,
-	Block[{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[_a, "FunctionLocalVariable"]
+	Block[{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[_a, "FunctionLocalVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "Block[{a}, _a]"
@@ -84,8 +84,8 @@ Test[
 Test[
 	With[{a}, __a] // MakeBoxes // AnnotateSyntax
 	,
-	With[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[__a, "LocalVariable"]
+	With[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[__a, "LocalVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "With[{a}, __a]"
@@ -95,8 +95,8 @@ Test[
 Test[
 	Module[{a}, ___a] // MakeBoxes // AnnotateSyntax
 	,
-	Module[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[___a, "LocalVariable"]
+	Module[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[___a, "LocalVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "Module[{a}, ___a]"
@@ -106,8 +106,8 @@ Test[
 Test[
 	Block[{a}, b] // MakeBoxes // AnnotateSyntax
 	,
-	Block[{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[b, "UndefinedSymbol"]
+	Block[{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Block[{a}, b]"
@@ -117,8 +117,8 @@ Test[
 Test[
 	With[{a}, a_b] // MakeBoxes // AnnotateSyntax
 	,
-	With[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		syntaxExpr[a_b, "LocalVariable"]
+	With[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		SyntaxExpr[a_b, "LocalVariable"]
 	] // MakeBoxes
 	,
 	TestID -> "With[{a}, a_b]"
@@ -128,7 +128,7 @@ Test[
 Test[
 	Module[{b}, a_b] // MakeBoxes // AnnotateSyntax
 	,
-	Module[{syntaxExpr[b, "LocalVariable", "UndefinedSymbol"]},
+	Module[{SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"]},
 		a_b
 	] // MakeBoxes
 	,
@@ -141,12 +141,12 @@ Test[
 	,
 	Block[
 		{
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] =
-				syntaxExpr[b, "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[b, "UndefinedSymbol"]
 		}
 		,
-		syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-		syntaxExpr[b, "UndefinedSymbol"]
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "Block[{a = b}, a b]"
@@ -158,11 +158,11 @@ Test[
 	,
 	With[
 		{
-			syntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
-				syntaxExpr[a, "UndefinedSymbol"]
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[a, "UndefinedSymbol"]
 		}
 		,
-		syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
 	] // MakeBoxes
 	,
 	TestID -> "With[{a = a}, a]"

--- a/SyntaxAnnotations/Tests/Integration/ScopingNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/ScopingNested.mt
@@ -17,10 +17,10 @@ Get["SyntaxAnnotations`Tests`Integration`init`"]
 Test[
 	With[{a}, Block[{b}, a b]] // MakeBoxes // AnnotateSyntax
 	,
-	With[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
-		Block[{syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]},
-			syntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+	With[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+		Block[{SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]},
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
 		]
 	] // MakeBoxes
 	,
@@ -31,14 +31,14 @@ Test[
 Test[
 	With[{a}, With[{a}, a]] // MakeBoxes // AnnotateSyntax
 	,
-	With[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+	With[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
 		With[
 			{
-				syntaxExpr[a,
+				SyntaxExpr[a,
 					"LocalScopeConflict", "LocalVariable", "UndefinedSymbol"
 				]
 			},
-			syntaxExpr[a,
+			SyntaxExpr[a,
 				"LocalScopeConflict", "LocalVariable", "UndefinedSymbol"
 			]
 		]
@@ -51,14 +51,14 @@ Test[
 Test[
 	Module[{a}, Module[{a}, a]] // MakeBoxes // AnnotateSyntax
 	,
-	Module[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+	Module[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
 		Module[
 			{
-				syntaxExpr[a,
+				SyntaxExpr[a,
 					"LocalScopeConflict", "LocalVariable", "UndefinedSymbol"
 				]
 			},
-			syntaxExpr[a,
+			SyntaxExpr[a,
 				"LocalScopeConflict", "LocalVariable", "UndefinedSymbol"
 			]
 		]
@@ -71,15 +71,15 @@ Test[
 Test[
 	Block[{a}, Block[{a}, a]] // MakeBoxes // AnnotateSyntax
 	,
-	Block[{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
+	Block[{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
 		Block[
 			{
-				syntaxExpr[a,
+				SyntaxExpr[a,
 					"LocalScopeConflict", "FunctionLocalVariable",
 					"UndefinedSymbol"
 				]
 			},
-			syntaxExpr[a,
+			SyntaxExpr[a,
 				"LocalScopeConflict", "FunctionLocalVariable",
 				"UndefinedSymbol"
 			]
@@ -93,15 +93,15 @@ Test[
 Test[
 	Module[{a}, Block[{a}, a]] // MakeBoxes // AnnotateSyntax
 	,
-	Module[{syntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+	Module[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
 		Block[
 			{
-				syntaxExpr[a,
+				SyntaxExpr[a,
 					"LocalScopeConflict", "FunctionLocalVariable",
 					"LocalVariable", "UndefinedSymbol"
 				]
 			},
-			syntaxExpr[a,
+			SyntaxExpr[a,
 				"LocalScopeConflict", "FunctionLocalVariable", "LocalVariable",
 				"UndefinedSymbol"
 			]
@@ -115,14 +115,14 @@ Test[
 Test[
 	Block[{a}, With[{b=a}, a b]] // MakeBoxes // AnnotateSyntax
 	,
-	Block[{syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
+	Block[{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
 		With[
 			{
-				syntaxExpr[b, "LocalVariable", "UndefinedSymbol"] =
-					syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
+				SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"] =
+					SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]
 			},
-			syntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
-			syntaxExpr[b, "LocalVariable", "UndefinedSymbol"]
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+			SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"]
 		]
 	] // MakeBoxes
 	,

--- a/SyntaxAnnotations/Tests/Integration/Utilities.m
+++ b/SyntaxAnnotations/Tests/Integration/Utilities.m
@@ -12,9 +12,15 @@ ClearAll["`*"]
 (*Usage messages*)
 
 
-syntaxExpr::usage =
+SyntaxBox::usage =
 "\
-syntaxExpr[expr, types] \
+SyntaxBox[expr, type1, type2, ...] \
+represents boxes that in an expression perform sytnax roles of given types."
+
+
+SyntaxExpr::usage =
+"\
+SyntaxExpr[expr, type1, type2, ...] \
 converted to boxes gives SyntaxBox with expr converted to boxes and given \
 annotation types."
 
@@ -26,14 +32,11 @@ annotation types."
 Begin["`Private`"]
 
 
-Needs["SyntaxAnnotations`"]
-
-
 (* ::Subsection:: *)
 (*syntaxExpr*)
 
 
-MakeBoxes[syntaxExpr[expr_, types___], StandardForm] ^:=
+MakeBoxes[SyntaxExpr[expr_, types___], StandardForm] ^:=
 	SyntaxBox[MakeBoxes[expr], types]
 
 

--- a/SyntaxAnnotations/Tests/Integration/init.m
+++ b/SyntaxAnnotations/Tests/Integration/init.m
@@ -3,9 +3,4 @@
 Get["SyntaxAnnotations`"]
 Get["SyntaxAnnotations`Tests`Integration`Utilities`"]
 
-SetOptions[AnnotateSyntax,
-	"BoxRules" -> {
-		SyntaxBox[boxes_, types__] :>
-			SyntaxBox[boxes, Sequence @@ NormalizeAnnotationTypes[types]]
-	}
-]
+SetOptions[AnnotateSyntax, "Annotation" -> (SyntaxBox[#1, Sequence @@ #2]&)]

--- a/SyntaxAnnotations/Tests/Unit/extractArgs.mt
+++ b/SyntaxAnnotations/Tests/Unit/extractArgs.mt
@@ -51,36 +51,36 @@ Test[
 
 
 (* ::Subsection:: *)
-(*SyntaxBox*)
+(*syntaxBox*)
 
 
 Test[
-	extractArgs[SyntaxBox["a", type], {1}]
+	extractArgs[syntaxBox["a", type], {1}]
 	,
 	{"a"}
 	,
-	TestID -> "SyntaxBox: {1}"
+	TestID -> "syntaxBox: {1}"
 ]
 Test[
-	extractArgs[SyntaxBox["a", type], {1, 2}]
+	extractArgs[syntaxBox["a", type], {1, 2}]
 	,
 	{"a"}
 	,
-	TestID -> "SyntaxBox: {1, 2}"
+	TestID -> "syntaxBox: {1, 2}"
 ]
 Test[
-	extractArgs[SyntaxBox["a", type], {2, Infinity}]
+	extractArgs[syntaxBox["a", type], {2, Infinity}]
 	,
 	{}
 	,
-	TestID -> "SyntaxBox: {2, Infinity}"
+	TestID -> "syntaxBox: {2, Infinity}"
 ]
 Test[
-	extractArgs[SyntaxBox["a", type], 0]
+	extractArgs[syntaxBox["a", type], 0]
 	,
 	{"a"}
 	,
-	TestID -> "SyntaxBox: 0"
+	TestID -> "syntaxBox: 0"
 ]
 
 
@@ -125,7 +125,7 @@ Test[
 Test[
 	extractArgs[
 		RowBox[{
-			SyntaxBox["c", "Undefined"], ",",
+			syntaxBox["c", "Undefined"], ",",
 			RowBox[{"x", "=", "y"}], ",",
 			"e"
 		}],
@@ -139,7 +139,7 @@ Test[
 Test[
 	extractArgs[
 		RowBox[{
-			SyntaxBox["c", "Undefined"], ",",
+			syntaxBox["c", "Undefined"], ",",
 			RowBox[{"x", "=", "y"}], ",",
 			"e"
 		}],
@@ -153,7 +153,7 @@ Test[
 Test[
 	extractArgs[
 		RowBox[{
-			SyntaxBox["c", "Undefined"], ",",
+			syntaxBox["c", "Undefined"], ",",
 			RowBox[{"x", "=", "y"}], ",",
 			"e"
 		}],
@@ -167,7 +167,7 @@ Test[
 Test[
 	extractArgs[
 		RowBox[{
-			SyntaxBox["c", "Undefined"], ",",
+			syntaxBox["c", "Undefined"], ",",
 			RowBox[{"x", "=", "y"}], ",",
 			"e"
 		}],


### PR DESCRIPTION
* Remove `$SyntaxBoxToStyleBox` list.
* Change public `SyntaxBox` to private `syntaxBox`.
* Change public `NormalizeAnnotationTypes` to private
`normalizeAnnotationTypes`.
* Replace `"BoxRules"` option of `AnnotateSyntax`, with `"Annotation"` option.
* Fix typo in `AnnotateSyntax` option name: `"BoxesToAnnoattiontypes"` ->`"BoxesToAnnotationTypes"`