### PR TITLE
Fix undefinedSymbolQ

### DIFF
--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -215,11 +215,16 @@ SetAttributes[undefinedSymbolQ, HoldFirst]
 
 
 undefinedSymbolQ[
-	sym : _String | _Symbol /;
-		Quiet[Context[sym], Context::notfound] === "System`"
-] := False
+	s : _String | _Symbol /; Quiet[Context[s], Context::notfound] === "System`"
+] = False
 
-undefinedSymbolQ[sym : _String?symbolNameQ | _Symbol] :=
+undefinedSymbolQ[name_String /; StringFreeQ[name, WhitespaceCharacter]] :=
+	With[{heldSym = Quiet @ MakeExpression[name, StandardForm]},
+		undefinedSymbolQ @@ heldSym /;
+			MatchQ[heldSym, HoldComplete[Except[Null | Symbol[___], _Symbol]]]
+	]
+
+undefinedSymbolQ[sym_Symbol] :=
 	! MemberQ[Language`ExtendedDefinition[sym][[1, 2, ;; -2, 2]], Except[{}]]
 
 undefinedSymbolQ[_] = False

--- a/SyntaxAnnotations/Tests/Unit/undefinedSymbolQ.mt
+++ b/SyntaxAnnotations/Tests/Unit/undefinedSymbolQ.mt
@@ -300,6 +300,74 @@ Test[
 	TestID -> "built-in: String"
 ]
 
+Test[
+	undefinedSymbolQ[Null]
+	,
+	False
+	,
+	TestID -> "built-in Null: Symbol"
+]
+Test[
+	undefinedSymbolQ["Null"]
+	,
+	False
+	,
+	TestID -> "built-in Null: String"
+]
+
+Test[
+	undefinedSymbolQ[\[Infinity]]
+	,
+	False
+	,
+	TestID -> "parsed to built-in: Symbol"
+]
+Test[
+	undefinedSymbolQ["\[Infinity]"]
+	,
+	False
+	,
+	TestID -> "parsed to built-in: String"
+]
+
+
+Block[{a, b},
+	a := (b = "leak");
+	
+	Test[
+		undefinedSymbolQ[a]
+		,
+		False
+		,
+		TestID -> "evaluation leak: Symbol: returned value"
+	];
+	Test[
+		b // Hold[#]&
+		,
+		b // Hold
+		,
+		TestID -> "evaluation leak: Symbol: test variable"
+	]
+]
+Block[{a, b},
+	a := (b = "leak");
+	
+	Test[
+		undefinedSymbolQ["a"]
+		,
+		False
+		,
+		TestID -> "evaluation leak: String: returned value"
+	];
+	Test[
+		b // Hold[#]&
+		,
+		b // Hold
+		,
+		TestID -> "evaluation leak: String: test variable"
+	]
+]
+
 
 (* ::Section:: *)
 (*TearDown*)


### PR DESCRIPTION
Handle strings that are not names of ``System` `` symbols, but are parsed to ``System` `` symbols.