### PR TITLE
Fix extractLocalVariableNames

### DIFF
--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -286,10 +286,7 @@ extractLocalVariableNames["Manipulate"][
 	name
 
 extractLocalVariableNames["Function"][
-	name_String /;
-		StringMatchQ[name,
-			("_" .. | "") ~~ LetterCharacter ~~ WordCharacter...
-		]
+	name_String /; StringMatchQ[name, "_"... ~~ Except["_"]...]
 ] := extractSymbolName[name]
 
 extractLocalVariableNames["Scoping" | "Function"][
@@ -308,12 +305,8 @@ extractLocalVariableNames["Scoping" | "Function"][
 			RowBox[{_String, $assignmentOperators, __}] ->
 				RowBox[{}]
 		,
-		name_String /;
-			StringMatchQ[
-				name,
-				("_" .. | "") ~~ LetterCharacter ~~ WordCharacter...
-			] :>
-				extractSymbolName[name]
+		name_String /; StringMatchQ[name, "_"... ~~ Except["_"]...] :>
+			extractSymbolName[name]
 		,
 		{0, Infinity}
 	] // Flatten
@@ -335,15 +328,11 @@ extractLocalVariableNames["PatternName"][boxes_] :=
 	Alternatives @@ Cases[
 		boxes
 		,
-		(
-			name_String /; 
-				StringMatchQ[
-					name,
-					LetterCharacter ~~ WordCharacter ... ~~ "_" ~~
-						(WordCharacter | "_") ...
-				]
-		) | 
-			RowBox[{name_String, ":", __}] :> extractSymbolName[name]
+		Alternatives[
+			name_String /; StringMatchQ[name, Except["_"].. ~~ "_" ~~ ___], 
+			RowBox[{name_String, ":", __}]
+		] :>
+			extractSymbolName[name]
 		,
 		{0, Infinity}
 	] // Flatten

--- a/SyntaxAnnotations/Tests/Integration/Function.mt
+++ b/SyntaxAnnotations/Tests/Integration/Function.mt
@@ -131,6 +131,16 @@ Test[
 	,
 	TestID -> "Function[_a, a]"
 ]
+Test[
+	Function[_\[SpadeSuit]1, \[SpadeSuit]1] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		SyntaxExpr[_\[SpadeSuit]1, "PatternVariable"],
+		SyntaxExpr[\[SpadeSuit]1, "PatternVariable", "UndefinedSymbol"]
+	] // MakeBoxes
+	,
+	TestID -> "Function[_\\[SpadeSuit]1, \\[SpadeSuit]1]"
+]
 
 Test[
 	Function[a_, a] // MakeBoxes // AnnotateSyntax

--- a/SyntaxAnnotations/Tests/Integration/Patterns.mt
+++ b/SyntaxAnnotations/Tests/Integration/Patterns.mt
@@ -38,6 +38,16 @@ Test[
 	,
 	TestID -> "a_ -> a"
 ]
+Test[
+	AnnotateSyntax @ MakeBoxes[a\[UnderBracket]b_ -> a\[UnderBracket]b]
+	,
+	MakeBoxes[
+		SyntaxExpr[a\[UnderBracket]b_, "PatternVariable"] ->
+			SyntaxExpr[a\[UnderBracket]b, "UndefinedSymbol"]
+	]
+	,
+	TestID -> "a\\[UnderBracket]b_ -> a\\[UnderBracket]b"
+]
 
 
 Test[

--- a/SyntaxAnnotations/Tests/Integration/PatternsDelayed.mt
+++ b/SyntaxAnnotations/Tests/Integration/PatternsDelayed.mt
@@ -478,6 +478,20 @@ Test[
 	,
 	TestID -> "a b /: a_ b_ := a b"
 ]
+Test[
+	AnnotateSyntax @ MakeBoxes[\[Alpha] b /: \[Alpha]_ b_ := \[Alpha] b]
+	,
+	MakeBoxes[
+		SyntaxExpr[\[Alpha], "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] /:
+			SyntaxExpr[\[Alpha]_, "PatternVariable"] *
+			SyntaxExpr[b_, "PatternVariable"] :=
+				SyntaxExpr[\[Alpha], "PatternVariable", "UndefinedSymbol"] *
+				SyntaxExpr[b, "PatternVariable", "UndefinedSymbol"]
+	]
+	,
+	TestID -> "\\[Alpha] b /: \\[Alpha]_ b_ := \\[Alpha] b"
+]
 
 
 Test[


### PR DESCRIPTION
Allow special characters in symbol names.