### PR TITLE
Change "BoxesToAnnotationTypes" option to "StringBoxToTypes"

### DIFF
--- a/SyntaxAnnotations/Tests/Integration/Function.mt
+++ b/SyntaxAnnotations/Tests/Integration/Function.mt
@@ -273,6 +273,21 @@ Test[
 ]
 
 Test[
+	Function[{a = a}, a] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		{
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] =
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		}
+		,
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+	] // MakeBoxes
+	,
+	TestID -> "Function[{a = a}, a]"
+]
+
+Test[
 	Function[{a, b}, a b] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
@@ -440,6 +455,26 @@ Test[
 	}]
 	,
 	TestID -> "(a = b) \\[Function] a b"
+]
+
+Test[
+	RowBox[{
+		RowBox[{"(", RowBox[{"a", "=", "a"}], ")"}],
+		"\[Function]",
+		"a"
+	}] // AnnotateSyntax
+	,
+	RowBox[{
+		RowBox[{"(", RowBox[{
+			SyntaxBox["a", "PatternVariable", "UndefinedSymbol"],
+			"=",
+			SyntaxBox["a", "PatternVariable", "UndefinedSymbol"]
+		}], ")"}],
+		"\[Function]",
+		SyntaxBox["a", "PatternVariable", "UndefinedSymbol"]
+	}]
+	,
+	TestID -> "(a = a) \\[Function] a"
 ]
 
 

--- a/SyntaxAnnotations/Tests/Unit/extractSymbolName.mt
+++ b/SyntaxAnnotations/Tests/Unit/extractSymbolName.mt
@@ -19,7 +19,7 @@ PrependTo[$ContextPath, "SyntaxAnnotations`Private`"]
 Test[
 	extractSymbolName[""]
 	,
-	Alternatives[]
+	{}
 	,
 	TestID -> "empty"
 ]
@@ -27,7 +27,7 @@ Test[
 Test[
 	extractSymbolName["1"]
 	,
-	Alternatives[]
+	{}
 	,
 	TestID -> "integer"
 ]
@@ -35,7 +35,7 @@ Test[
 Test[
 	extractSymbolName["2a"]
 	,
-	Alternatives[]
+	{}
 	,
 	TestID -> "start with integer"
 ]
@@ -43,7 +43,7 @@ Test[
 Test[
 	extractSymbolName["b"]
 	,
-	Alternatives["b"]
+	{"b"}
 	,
 	TestID -> "single letter"
 ]
@@ -51,7 +51,7 @@ Test[
 Test[
 	extractSymbolName["c3"]
 	,
-	Alternatives["c3"]
+	{"c3"}
 	,
 	TestID -> "end with integer"
 ]
@@ -59,7 +59,7 @@ Test[
 Test[
 	extractSymbolName["_d"]
 	,
-	Alternatives["d"]
+	{"d"}
 	,
 	TestID -> "Blank with head"
 ]
@@ -67,7 +67,7 @@ Test[
 Test[
 	extractSymbolName["__e"]
 	,
-	Alternatives["e"]
+	{"e"}
 	,
 	TestID -> "BlankSequence with head"
 ]
@@ -75,7 +75,7 @@ Test[
 Test[
 	extractSymbolName["___f"]
 	,
-	Alternatives["f"]
+	{"f"}
 	,
 	TestID -> "BlankNullSequence with head"
 ]
@@ -83,7 +83,7 @@ Test[
 Test[
 	extractSymbolName["g_"]
 	,
-	Alternatives["g"]
+	{"g"}
 	,
 	TestID -> "named Blank"
 ]
@@ -91,7 +91,7 @@ Test[
 Test[
 	extractSymbolName["h__"]
 	,
-	Alternatives["h"]
+	{"h"}
 	,
 	TestID -> "named BlankSequence"
 ]
@@ -99,7 +99,7 @@ Test[
 Test[
 	extractSymbolName["i___"]
 	,
-	Alternatives["i"]
+	{"i"}
 	,
 	TestID -> "named BlankNullSequence"
 ]
@@ -107,7 +107,7 @@ Test[
 Test[
 	extractSymbolName["j_k"]
 	,
-	Alternatives["j"]
+	{"j"}
 	,
 	TestID -> "named Blank with head"
 ]
@@ -115,7 +115,7 @@ Test[
 Test[
 	extractSymbolName["l__m"]
 	,
-	Alternatives["l"]
+	{"l"}
 	,
 	TestID -> "named BlankSequence with head"
 ]
@@ -123,7 +123,7 @@ Test[
 Test[
 	extractSymbolName["n___o"]
 	,
-	Alternatives["n"]
+	{"n"}
 	,
 	TestID -> "named BlankNullSequence with head"
 ]
@@ -131,7 +131,7 @@ Test[
 Test[
 	extractSymbolName["aBc"]
 	,
-	Alternatives["aBc"]
+	{"aBc"}
 	,
 	TestID -> "multiple letters"
 ]
@@ -139,7 +139,7 @@ Test[
 Test[
 	extractSymbolName["a2c"]
 	,
-	Alternatives["a2c"]
+	{"a2c"}
 	,
 	TestID -> "integer inside"
 ]
@@ -147,7 +147,7 @@ Test[
 Test[
 	extractSymbolName["a_b__c"]
 	,
-	Alternatives["a"]
+	{"a"}
 	,
 	TestID -> "two underscore sequences"
 ]
@@ -155,7 +155,7 @@ Test[
 Test[
 	extractSymbolName["Block"]
 	,
-	Alternatives["Block"]
+	{"Block"}
 	,
 	TestID -> "built-in symbol name"
 ]


### PR DESCRIPTION
* Replace `$BoxesToAnnotationTypes` public symbol with private`$stringBoxToTypes`.

* Change `extractSymbolName` and `extractLocalVariableNames` functions to return `List` instead of a pattern, adapt tests.

* Change `annotateSyntaxInternal` to `parse` function. Instead of accepting and passing around list of rules, assigning syntax types to string boxes, store them as `DownValues` of `stringBoxTypes` and `patternNameTypes` functions. Add `modifyTypes` and `withModifiedTypes` function used inside new parser to assign types to symbol names.

* Add `extendedSyntaxInformation` for `\[Function]`. Add tests for assignment with single symbol in first argument of `Function` and `\[Function]`.