### PR TITLE
Fix annotations on LHS of assignments

### DIFF
--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -716,8 +716,11 @@ parse[
 			withModifiedTypes[{patternNameTypes},
 				{{"PatternVariable", funcName, "LHS"}, localVars}
 				,
-				Sequence @@ ReplaceAll[{tag, tagSep, lhs},
-					str_String :> parse[str]
+				(*	Block modifyTypes, so that constructs in LHS of rules and
+					assignments don't change syntax roles, since that's the
+					observed behavior. *)
+				Sequence @@ Block[{modifyTypes},
+					parse /@ {tag, tagSep, lhs}
 				]
 			]
 			,

--- a/SyntaxAnnotations/Tests/Integration/MixedNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/MixedNested.mt
@@ -471,6 +471,28 @@ Test[
 
 
 (* ::Subsection:: *)
+(*InfixMessageName in Patterns LHS, String in Patterns RHS*)
+
+
+Test[
+	RowBox[{RowBox[{"f", "::", "usage"}], "=", "\"\<something\>\""}] //
+		AnnotateSyntax
+	,
+	RowBox[{
+		RowBox[{
+			SyntaxBox["f", "UndefinedSymbol"],
+			"::",
+			SyntaxBox["usage", "String"]
+		}],
+		"=",
+		SyntaxBox["\"\<something\>\"", "String"]
+	}]
+	,
+	TestID -> "f::usage = \"something\""
+]
+
+
+(* ::Subsection:: *)
 (*Scopping in InfixMessageName*)
 
 


### PR DESCRIPTION
Allow full parsing just without changes in syntax roles of symbols.

Add test for assignment of message string.