### PR TITLE
Fix annotating of local variables in nested functions

### DIFF
--- a/SyntaxAnnotations/Tests/Integration/Function.mt
+++ b/SyntaxAnnotations/Tests/Integration/Function.mt
@@ -15,62 +15,138 @@ Get["SyntaxAnnotations`Tests`Integration`init`"]
 
 
 (* ::Subsection:: *)
-(*One argument*)
+(*&*)
 
 
 Test[
-	Function[a] // MakeBoxes // AnnotateSyntax
+	a & // MakeBoxes // AnnotateSyntax
 	,
-	Function[SyntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
+	SyntaxExpr[a, "UndefinedSymbol"] & // MakeBoxes
+	,
+	TestID -> "a &"
+]
+
+Test[
+	# & // MakeBoxes // AnnotateSyntax
+	,
+	SyntaxExpr[#, "PatternVariable"] & // MakeBoxes
+	,
+	TestID -> "# &"
+]
+
+Test[
+	#2 & // MakeBoxes // AnnotateSyntax
+	,
+	SyntaxExpr[#2, "PatternVariable"] & // MakeBoxes
+	,
+	TestID -> "#2 &"
+]
+
+Test[
+	## & // MakeBoxes // AnnotateSyntax
+	,
+	SyntaxExpr[##, "PatternVariable"] & // MakeBoxes
+	,
+	TestID -> "## &"
+]
+
+Test[
+	##3 & // MakeBoxes // AnnotateSyntax
+	,
+	SyntaxExpr[##3, "PatternVariable"] & // MakeBoxes
+	,
+	TestID -> "##3 &"
+]
+
+If[$VersionNumber >= 10,
+	Test[
+		#name & // MakeBoxes // AnnotateSyntax
+		,
+		SyntaxExpr[#name, "PatternVariable"] & // MakeBoxes
+		,
+		TestID -> "#name &"
+	]
+]
+
+Test[
+	# + ##3 & // MakeBoxes // AnnotateSyntax
+	,
+	SyntaxExpr[#, "PatternVariable"] + SyntaxExpr[##3, "PatternVariable"] & //
+		MakeBoxes
+	,
+	TestID -> "# + ##3 &"
+]
+
+
+(* ::Subsection:: *)
+(*Function one argument*)
+
+
+Test[
+	RowBox[{"Function", "[", "a", "]"}] // AnnotateSyntax
+	,
+	RowBox[{"Function", "[", SyntaxBox["a", "UndefinedSymbol"], "]"}]
 	,
 	TestID -> "Function[a]"
 ]
 
 Test[
-	Function[#] // MakeBoxes // AnnotateSyntax
+	RowBox[{"Function", "[", "#", "]"}] // AnnotateSyntax
 	,
-	Function[SyntaxExpr[#, "PatternVariable"]] // MakeBoxes
+	RowBox[{"Function", "[", SyntaxBox["#", "PatternVariable"], "]"}]
 	,
 	TestID -> "Function[#]"
 ]
 
 Test[
-	Function[#2] // MakeBoxes // AnnotateSyntax
+	RowBox[{"Function", "[", "#1", "]"}] // AnnotateSyntax
 	,
-	Function[SyntaxExpr[#2, "PatternVariable"]] // MakeBoxes
+	RowBox[{"Function", "[", SyntaxBox["#1", "PatternVariable"], "]"}]
 	,
-	TestID -> "Function[#2]"
+	TestID -> "Function[#1]"
 ]
 
 Test[
-	Function[##] // MakeBoxes // AnnotateSyntax
+	RowBox[{"Function", "[", "##", "]"}] // AnnotateSyntax
 	,
-	Function[SyntaxExpr[##, "PatternVariable"]] // MakeBoxes
+	RowBox[{"Function", "[", SyntaxBox["##", "PatternVariable"], "]"}]
 	,
 	TestID -> "Function[##]"
 ]
 
 Test[
-	Function[##3] // MakeBoxes // AnnotateSyntax
+	RowBox[{"Function", "[", "##11", "]"}] // AnnotateSyntax
 	,
-	Function[SyntaxExpr[##3, "PatternVariable"]] // MakeBoxes
+	RowBox[{"Function", "[", SyntaxBox["##11", "PatternVariable"], "]"}]
 	,
-	TestID -> "Function[##3]"
+	TestID -> "Function[##11]"
 ]
 
 If[$VersionNumber >= 10,
 	Test[
-		Function[#name] // MakeBoxes // AnnotateSyntax
+		RowBox[{"Function", "[", "#name", "]"}] // AnnotateSyntax
 		,
-		Function[SyntaxExpr[#name, "PatternVariable"]] // MakeBoxes
+		RowBox[{"Function", "[", SyntaxBox["#name", "PatternVariable"], "]"}]
 		,
 		TestID -> "Function[#name]"
 	]
 ]
 
+Test[
+	RowBox[{"Function", "[", RowBox[{"##", "+", "#9"}], "]"}] // AnnotateSyntax
+	,
+	RowBox[{"Function", "[", RowBox[{
+		SyntaxBox["##", "PatternVariable"],
+		"+",
+		SyntaxBox["#9", "PatternVariable"]
+	}], "]"}]
+	,
+	TestID -> "Function[## + #9]"
+]
+
 
 (* ::Subsection:: *)
-(*Two arguments*)
+(*Function two arguments*)
 
 
 (* ::Subsubsection:: *)
@@ -288,6 +364,36 @@ Test[
 ]
 
 Test[
+	Function[{a_ = b}, a b] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		{SyntaxExpr[a_, "PatternVariable"] = SyntaxExpr[b, "UndefinedSymbol"]},
+		SyntaxExpr[a, "UndefinedSymbol"] SyntaxExpr[b, "UndefinedSymbol"]
+	] // MakeBoxes
+	,
+	TestID -> "Function[{a_ = b}, a b]"
+]
+
+Test[
+	Function[{f[a] = a b}, f a b] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		{
+			SyntaxExpr[f, "PatternVariable", "UndefinedSymbol"][
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+			] =
+				SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+				SyntaxExpr[b, "UndefinedSymbol"]
+		},
+		SyntaxExpr[f, "PatternVariable", "UndefinedSymbol"] *
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"]
+	] // MakeBoxes
+	,
+	TestID -> "Function[{a_ = b}, a b]"
+]
+
+Test[
 	Function[{a, b}, a b] // MakeBoxes // AnnotateSyntax
 	,
 	Function[
@@ -305,7 +411,7 @@ Test[
 
 
 (* ::Subsection:: *)
-(*Three arguments*)
+(*Function three arguments*)
 
 
 Test[

--- a/SyntaxAnnotations/Tests/Integration/FunctionNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/FunctionNested.mt
@@ -1,0 +1,255 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["SyntaxAnnotations`Tests`Integration`FunctionNested`", {"MUnit`"}]
+
+
+Get["SyntaxAnnotations`Tests`Integration`init`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+Test[
+	Function[a, Function[a, a]] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		Function[
+			SyntaxExpr[a,
+				"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
+			],
+			SyntaxExpr[a,
+				"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
+			]
+		]
+	] // MakeBoxes
+	,
+	TestID -> "Function[a, Function[a, a]]"
+]
+Test[
+	Function[a, Function[{a}, a]] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		Function[
+			{
+				SyntaxExpr[a,
+					"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
+				]
+			},
+			SyntaxExpr[a,
+				"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
+			]
+		]
+	] // MakeBoxes
+	,
+	TestID -> "Function[a, Function[{a}, a]]"
+]
+Test[
+	Function[{a}, Function[a, a]] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		{SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
+		Function[
+			SyntaxExpr[a,
+				"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
+			],
+			SyntaxExpr[a,
+				"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
+			]
+		]
+	] // MakeBoxes
+	,
+	TestID -> "Function[{a}, Function[a, a]]"
+]
+Test[
+	Function[{a}, Function[{a}, a]] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		{SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
+		Function[
+			{
+				SyntaxExpr[a,
+					"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
+				]
+			},
+			SyntaxExpr[a,
+				"LocalScopeConflict", "PatternVariable", "UndefinedSymbol"
+			]
+		]
+	] // MakeBoxes
+	,
+	TestID -> "Function[{a}, Function[{a}, a]]"
+]
+
+Test[
+	Function[Function[a, a], a Function] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		Function[
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		],
+		SyntaxExpr[a, "UndefinedSymbol"] Function
+	] // MakeBoxes
+	,
+	TestID -> "Function[Function[a, a], a Function]"
+]
+Test[
+	Function[Function[{a}, a], a Function] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		Function[
+			{SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		],
+		SyntaxExpr[a, "UndefinedSymbol"] Function
+	] // MakeBoxes
+	,
+	TestID -> "Function[Function[{a}, a], a Function]"
+]
+Test[
+	Function[{Function[a, a]}, a Function] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		{SyntaxExpr[Function, "PatternVariable"][
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		]},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[Function, "PatternVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "Function[{Function[a, a]}, a Function]"
+]
+Test[
+	Function[{Function[{a}, a]}, a Function] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		{SyntaxExpr[Function, "PatternVariable"][
+			{SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]},
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"]
+		]},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[Function, "PatternVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "Function[{Function[{a}, a]}, a Function]"
+]
+
+
+Test[
+	RowBox[{"Function", "[",
+		RowBox[{"#", " ", RowBox[{"Function", "[", "##6", "]"}]}],
+	"]"}] // AnnotateSyntax
+	,
+	RowBox[{"Function", "[",
+		RowBox[{SyntaxBox["#", "PatternVariable"],
+		" ",
+		RowBox[{"Function", "[", SyntaxBox["##6", "PatternVariable"], "]"}]}],
+	"]"}]
+	,
+	TestID -> "Function[# Function[##6]]"
+]
+
+
+Test[
+	RowBox[{RowBox[{RowBox[{"Function", "[", "#2", "]"}], "+", "#2"}], "&"}] //
+		AnnotateSyntax
+	,
+	RowBox[{RowBox[{
+		RowBox[{"Function", "[", SyntaxBox["#2", "PatternVariable"], "]"}],
+		"+",
+		SyntaxBox["#2", "PatternVariable"]
+	}], "&"}]
+	,
+	TestID -> "(Function[#2] #2)&"
+]
+
+
+Test[
+	Function[a, (a #)&] // MakeBoxes // AnnotateSyntax
+	,
+	Function[
+		SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"],
+		(
+			SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+			SyntaxExpr[#, "PatternVariable"]
+		)&
+	] // MakeBoxes
+	,
+	TestID -> "Function[a, (a #)&]"
+]
+
+
+Test[
+	RowBox[{
+		RowBox[{"a", "\[Function]", "b"}],
+		"\[Function]",
+		RowBox[{"a", " ", "b"}]}
+	] // AnnotateSyntax
+	,
+	RowBox[{
+		RowBox[{
+			SyntaxBox["a", "PatternVariable", "UndefinedSymbol"],
+			"\[Function]",
+			SyntaxBox["b", "PatternVariable", "UndefinedSymbol"]}],
+		"\[Function]",
+		RowBox[{
+			SyntaxBox["a", "UndefinedSymbol"],
+			" ",
+			SyntaxBox["b", "PatternVariable", "UndefinedSymbol"]
+		}]
+	}]
+	,
+	TestID -> "((a \\[Function] b) \\[Function] a b)"
+]
+
+
+Test[
+	RowBox[{
+		RowBox[{"Function", "[",
+			RowBox[{RowBox[{"{", "a", "}"}], ",", "b", ",", "c"}],
+		"]"}],
+		"\[Function]",
+		RowBox[{"a", " ", "b", " ", "c", " ", "Function"}]
+	}] // AnnotateSyntax
+	,
+	RowBox[{
+		RowBox[{SyntaxBox["Function", "PatternVariable"], "[",
+			RowBox[{
+				RowBox[{"{",
+					SyntaxBox["a", "PatternVariable", "UndefinedSymbol"],
+				"}"}], ",",
+				SyntaxBox["b", "UndefinedSymbol"], ",",
+				SyntaxBox["c", "UndefinedSymbol"]
+			}],
+		"]"}],
+		"\[Function]",
+		RowBox[{
+			SyntaxBox["a", "UndefinedSymbol"], " ",
+			SyntaxBox["b", "UndefinedSymbol"], " ",
+			SyntaxBox["c", "UndefinedSymbol"], " ",
+			SyntaxBox["Function", "PatternVariable"]
+		}]
+	}]
+	,
+	TestID -> "Function[{a}, b, c] \\[Function] a b c Function"
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/SyntaxAnnotations/Tests/Integration/Functions.mt
+++ b/SyntaxAnnotations/Tests/Integration/Functions.mt
@@ -298,6 +298,18 @@ Test[
 ]
 
 
+Test[
+	Solve[Solve, {Solve}] // MakeBoxes // AnnotateSyntax
+	,
+	Solve[
+		SyntaxExpr[Solve, "FunctionLocalVariable"],
+		{SyntaxExpr[Solve, "FunctionLocalVariable"]}
+	] // MakeBoxes
+	,
+	TestID -> "Solve[Solve, {Solve}]"
+]
+
+
 (* ::Subsection:: *)
 (*Limit*)
 

--- a/SyntaxAnnotations/Tests/Integration/PatternsDelayedNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/PatternsDelayedNested.mt
@@ -20,6 +20,10 @@ Get["SyntaxAnnotations`Tests`Integration`init`"]
 (*RuleDelayed*)
 
 
+(* ::Subsubsection:: *)
+(*RuleDelayed*)
+
+
 Test[
 	AnnotateSyntax @ MakeBoxes[a_ :> (b_ :> a b)]
 	,
@@ -65,7 +69,47 @@ Test[
 ]
 
 
+Test[
+	AnnotateSyntax @ MakeBoxes[(a_ :> a_) :> a a_]
+	,
+	MakeBoxes[
+		 (
+		 	SyntaxExpr[a_, "PatternVariable"] :>
+		 		SyntaxExpr[a_, "PatternVariable", "LocalScopeConflict"]
+		 ) :>
+		 	SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		 	SyntaxExpr[a_, "LocalScopeConflict"]
+	]
+	,
+	TestID -> "(a_ :> a_) :> a a_"
+]
+
+
+(* ::Subsubsection:: *)
+(*SetDelayed*)
+
+
+Test[
+	AnnotateSyntax @ MakeBoxes[(a_ := a_) :> a a_]
+	,
+	MakeBoxes[
+		 (
+		 	SyntaxExpr[a_, "PatternVariable"] :=
+		 		SyntaxExpr[a_, "PatternVariable", "LocalScopeConflict"]
+		 ) :>
+		 	SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		 	SyntaxExpr[a_, "LocalScopeConflict"]
+	]
+	,
+	TestID -> "(a_ := a_) :> a a_"
+]
+
+
 (* ::Subsection:: *)
+(*SetDelayed*)
+
+
+(* ::Subsubsection:: *)
 (*SetDelayed*)
 
 
@@ -114,7 +158,47 @@ Test[
 ]
 
 
+Test[
+	AnnotateSyntax @ MakeBoxes[(a_ := a_) := a a_]
+	,
+	MakeBoxes[
+		 (
+		 	SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] :=
+		 		SyntaxExpr[a_, "LocalScopeConflict"]
+		 ) :=
+		 	SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		 	SyntaxExpr[a_, "LocalScopeConflict"]
+	]
+	,
+	TestID -> "(a_ := a_) := a a_"
+]
+
+
+(* ::Subsubsection:: *)
+(*RuleDelayed*)
+
+
+Test[
+	AnnotateSyntax @ MakeBoxes[(a_ :> a_) := a a_]
+	,
+	MakeBoxes[
+		 (
+		 	SyntaxExpr[a_, "PatternVariable"] :>
+		 		SyntaxExpr[a_, "PatternVariable"]
+		 ) :=
+		 	SyntaxExpr[a, "PatternVariable", "UndefinedSymbol"] *
+		 	SyntaxExpr[a_, "LocalScopeConflict"]
+	]
+	,
+	TestID -> "(a_ :> a_) := a a_"
+]
+
+
 (* ::Subsection:: *)
+(*UpSetDelayed*)
+
+
+(* ::Subsubsection:: *)
 (*UpSetDelayed*)
 
 
@@ -164,6 +248,10 @@ Test[
 
 
 (* ::Subsection:: *)
+(*TagSetDelayed*)
+
+
+(* ::Subsubsection:: *)
 (*TagSetDelayed*)
 
 

--- a/SyntaxAnnotations/Tests/Integration/PatternsNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/PatternsNested.mt
@@ -54,7 +54,7 @@ Test[
 	,
 	MakeBoxes[
 		(
-			SyntaxExpr[a_, "PatternVariable"] =
+			SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] =
 				SyntaxExpr[a_, "PatternVariable"]
 		) =
 			SyntaxExpr[a, "UndefinedSymbol"]
@@ -85,7 +85,7 @@ Test[
 	,
 	MakeBoxes[
 		(
-			SyntaxExpr[a_, "PatternVariable"] ^=
+			SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] ^=
 				SyntaxExpr[a_, "PatternVariable"]
 		) ^=
 			SyntaxExpr[a, "UndefinedSymbol"]
@@ -116,8 +116,8 @@ Test[
 	,
 	MakeBoxes[
 		(
-			SyntaxExpr[a_, "PatternVariable"] /:
-				SyntaxExpr[a_, "PatternVariable"] =
+			SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] /:
+				SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] =
 					SyntaxExpr[a_, "PatternVariable"]
 		) /:
 			SyntaxExpr[a, "UndefinedSymbol"] = SyntaxExpr[a, "UndefinedSymbol"]
@@ -132,8 +132,8 @@ Test[
 	,
 	MakeBoxes[
 		SyntaxExpr[a, "UndefinedSymbol"] /: (
-			SyntaxExpr[a_, "PatternVariable"] /:
-				SyntaxExpr[a_, "PatternVariable"] =
+			SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] /:
+				SyntaxExpr[a_, "LocalScopeConflict", "PatternVariable"] =
 					SyntaxExpr[a_, "PatternVariable"]
 		) = SyntaxExpr[a, "UndefinedSymbol"]
 	]

--- a/SyntaxAnnotations/Tests/Integration/Scoping.mt
+++ b/SyntaxAnnotations/Tests/Integration/Scoping.mt
@@ -27,6 +27,26 @@ Test[
 
 
 Test[
+	Module[{}, a] // MakeBoxes // AnnotateSyntax
+	,
+	Module[{}, SyntaxExpr[a, "UndefinedSymbol"]] // MakeBoxes
+	,
+	TestID -> "Module[{}, a]"
+]
+
+Test[
+	Block[RawBoxes@RowBox[{"{", ",", "}"}], a] // MakeBoxes // AnnotateSyntax
+	,
+	Block[
+		RawBoxes@RowBox[{"{", ",", "}"}],
+		SyntaxExpr[a, "UndefinedSymbol"]
+	] // MakeBoxes
+	,
+	TestID -> "Block[{,}, a]"
+]
+
+
+Test[
 	Module[{a}, a] // MakeBoxes // AnnotateSyntax
 	,
 	Module[{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
@@ -166,6 +186,71 @@ Test[
 	] // MakeBoxes
 	,
 	TestID -> "With[{a = a}, a]"
+]
+
+
+Test[
+	Module[{a = x, b = y, c = z}, a b c x y z] // MakeBoxes // AnnotateSyntax
+	,
+	Module[
+		{
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[x, "UndefinedSymbol"],
+			SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[y, "UndefinedSymbol"],
+			SyntaxExpr[c, "LocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[z, "UndefinedSymbol"]
+		}
+		,
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[c, "LocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[x, "UndefinedSymbol"] *
+		SyntaxExpr[y, "UndefinedSymbol"] *
+		SyntaxExpr[z, "UndefinedSymbol"]
+	] // MakeBoxes
+	,
+	TestID -> "Module[{a = x, b = y, c = z}, a b c x y z]"
+]
+
+
+Test[
+	Block[{a = b, b = a}, a b] // MakeBoxes // AnnotateSyntax
+	,
+	Block[
+		{
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[b, "UndefinedSymbol"],
+			SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[a, "UndefinedSymbol"]
+		}
+		,
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+	] // MakeBoxes
+	,
+	TestID -> "Block[{a = b, b = a}, a b]"
+]
+
+
+Test[
+	With[{f[a = a, b = b]}, f a b] // MakeBoxes // AnnotateSyntax
+	,
+	With[
+		{SyntaxExpr[f, "LocalVariable", "UndefinedSymbol"][
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+			,
+			SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"]
+		]}
+		,
+		SyntaxExpr[f, "LocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"]
+	] // MakeBoxes
+	,
+	TestID -> "Module[{f[a = a, b = b]}, f a b]"
 ]
 
 

--- a/SyntaxAnnotations/Tests/Integration/ScopingNested.mt
+++ b/SyntaxAnnotations/Tests/Integration/ScopingNested.mt
@@ -14,6 +14,10 @@ Get["SyntaxAnnotations`Tests`Integration`init`"]
 (*Tests*)
 
 
+(* ::Subsection:: *)
+(*Inner scoping in body*)
+
+
 Test[
 	With[{a}, Block[{b}, a b]] // MakeBoxes // AnnotateSyntax
 	,
@@ -97,12 +101,12 @@ Test[
 		Block[
 			{
 				SyntaxExpr[a,
-					"LocalScopeConflict", "FunctionLocalVariable",
-					"LocalVariable", "UndefinedSymbol"
+					"LocalScopeConflict", "LocalVariable",
+					"FunctionLocalVariable", "UndefinedSymbol"
 				]
 			},
 			SyntaxExpr[a,
-				"LocalScopeConflict", "FunctionLocalVariable", "LocalVariable",
+				"LocalScopeConflict", "LocalVariable", "FunctionLocalVariable",
 				"UndefinedSymbol"
 			]
 		]
@@ -127,6 +131,376 @@ Test[
 	] // MakeBoxes
 	,
 	TestID -> "Block[{a}, With[{b=a}, a b]]"
+]
+
+
+(* ::Subsubsection:: *)
+(*Non-assignment*)
+
+
+Test[
+	With[{Module[{a}, a]}, a Module] // MakeBoxes // AnnotateSyntax
+	,
+	With[
+		{
+			SyntaxExpr[Module, "LocalVariable"][
+				{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+				SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+			]
+		},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[Module, "LocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "With[{Module[{a}, a]}, a Module]"
+]
+Test[
+	Module[{With[{a}, b]}, a b With] // MakeBoxes // AnnotateSyntax
+	,
+	Module[
+		{
+			SyntaxExpr[With, "LocalVariable"][
+				{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+				SyntaxExpr[b, "UndefinedSymbol"]
+			]
+		},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[With, "LocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "Module[{With[{a}, b]}, a b With]"
+]
+
+
+Test[
+	Block[{Module[{a = a}, a]}, a Module] // MakeBoxes // AnnotateSyntax
+	,
+	Block[
+		{
+			SyntaxExpr[Module, "FunctionLocalVariable"][
+				{
+					SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
+						SyntaxExpr[a, "UndefinedSymbol"]
+				},
+				SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+			]
+		},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[Module, "FunctionLocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "Block[{Module[{a = a}, a]}, a Module]"
+]
+Test[
+	With[{With[{a := b}, c]}, a b c With] // MakeBoxes // AnnotateSyntax
+	,
+	With[
+		{
+			SyntaxExpr[With, "LocalVariable"][
+				{
+					SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] :=
+						SyntaxExpr[b, "UndefinedSymbol"]
+				},
+				SyntaxExpr[c, "UndefinedSymbol"]
+			]
+		},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[With, "LocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "With[{With[{a := b}, c]}, a b c With]"
+]
+
+
+(* ::Subsubsection:: *)
+(*Assignment LHS*)
+
+
+Test[
+	With[{Module[{a}, a] := a}, a Module] // MakeBoxes // AnnotateSyntax
+	,
+	With[
+		{
+			SyntaxExpr[Module, "LocalVariable"][
+				{SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]},
+				SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+			] :=
+				SyntaxExpr[a, "UndefinedSymbol"]
+		},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[Module, "LocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "With[{Module[{a}, a] := a}, a Module]"
+]
+Test[
+	With[{Block[{a}, b] = c}, a b c Block] // MakeBoxes // AnnotateSyntax
+	,
+	With[
+		{
+			SyntaxExpr[Block, "LocalVariable"][
+				{SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"]},
+				SyntaxExpr[b, "UndefinedSymbol"]
+			] =
+				SyntaxExpr[c, "UndefinedSymbol"]
+		},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[Block, "LocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "With[{Block[{a}, b] = c}, a b c Block]"
+]
+
+
+Test[
+	Module[{With[{a := a}, a] = a}, a With] // MakeBoxes // AnnotateSyntax
+	,
+	Module[
+		{
+			SyntaxExpr[With, "LocalVariable"][
+				{
+					SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] :=
+						SyntaxExpr[a, "UndefinedSymbol"]
+				},
+				SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+			] =
+				SyntaxExpr[a, "UndefinedSymbol"]
+		},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[With, "LocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "Module[{With[{a := a}, a] = a}, a With]"
+]
+Test[
+	Module[{Module[{a = b}, c] := d}, a b c d Module] //
+		MakeBoxes // AnnotateSyntax
+	,
+	Module[
+		{
+			SyntaxExpr[Module, "LocalVariable"][
+				{
+					SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
+						SyntaxExpr[b, "UndefinedSymbol"]
+				},
+				SyntaxExpr[c, "UndefinedSymbol"]
+			] :=
+				SyntaxExpr[d, "UndefinedSymbol"]
+		},
+		SyntaxExpr[a, "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[d, "UndefinedSymbol"] *
+		SyntaxExpr[Module, "LocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "Module[{Module[{a = b}, c] := d}, a b c d Module]"
+]
+
+
+(* ::Subsubsection:: *)
+(*Assignment RHS*)
+
+
+Test[
+	Module[{a = Block[{a}, a]}, a Block] // MakeBoxes // AnnotateSyntax
+	,
+	Module[
+		{
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
+				Block[
+					{
+						SyntaxExpr[a,
+							"LocalScopeConflict", "LocalVariable",
+							"FunctionLocalVariable", "UndefinedSymbol"
+						]
+					},
+					SyntaxExpr[a,
+						"LocalScopeConflict", "LocalVariable",
+						"FunctionLocalVariable", "UndefinedSymbol"
+					]
+				]
+		},
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+		Block
+	] // MakeBoxes
+	,
+	TestID -> "Module[{a = Block[{a}, a]}, a Block]"
+]
+Test[
+	Block[{a := With[{b}, c]}, a b c With] // MakeBoxes // AnnotateSyntax
+	,
+	Block[
+		{
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] :=
+				With[{SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"]},
+					SyntaxExpr[c, "UndefinedSymbol"]
+				]
+		},
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		With
+	] // MakeBoxes
+	,
+	TestID -> "Block[{a := With[{b}, c]}, a b c With]"
+]
+
+
+Test[
+	Block[{a := Module[{a := a}, a]}, a Module] // MakeBoxes // AnnotateSyntax
+	,
+	Block[
+		{
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] :=
+				Module[
+					{
+						SyntaxExpr[a,
+							"LocalScopeConflict", "LocalVariable",
+							"UndefinedSymbol"
+						] :=
+							SyntaxExpr[a,
+								"LocalScopeConflict", "UndefinedSymbol"
+							]
+					},
+					SyntaxExpr[a,
+						"LocalScopeConflict", "LocalVariable",
+						"UndefinedSymbol"
+					]
+				]
+		},
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		Module
+	] // MakeBoxes
+	,
+	TestID -> "Block[{a := Module[{a := a}, a]}, a Module]"
+]
+Test[
+	Block[{a = Block[{b = c}, d]}, a b c d Block] //
+		MakeBoxes // AnnotateSyntax
+	,
+	Block[
+		{
+			SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] =
+				Block[
+					{
+						SyntaxExpr[b,
+							"FunctionLocalVariable", "UndefinedSymbol"
+						] =
+							SyntaxExpr[c, "UndefinedSymbol"]
+					},
+					SyntaxExpr[d, "UndefinedSymbol"]
+				]
+		},
+		SyntaxExpr[a, "FunctionLocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		SyntaxExpr[c, "UndefinedSymbol"] *
+		SyntaxExpr[d, "UndefinedSymbol"] *
+		Block
+	] // MakeBoxes
+	,
+	TestID -> "Block[{a = Block[{b = c}, d]}, a b c d Block]"
+]
+
+
+Test[
+	With[{a = a Block[{b := a}, a b]}, a b Block] //
+		MakeBoxes // AnnotateSyntax
+	,
+	With[
+		{
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
+				SyntaxExpr[a, "UndefinedSymbol"] *
+				Block[
+					{
+						SyntaxExpr[b,
+							"FunctionLocalVariable", "UndefinedSymbol"
+						] :=
+							SyntaxExpr[a, "UndefinedSymbol"]
+					},
+					SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+					SyntaxExpr[b, "FunctionLocalVariable", "UndefinedSymbol"]
+				]
+		},
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "UndefinedSymbol"] *
+		Block
+	] // MakeBoxes
+	,
+	TestID -> "With[{a = a Block[{b := a}, a b]}, a b Block]"
+]
+
+
+Test[
+	With[{a := With[a, a]}, a With] // MakeBoxes // AnnotateSyntax
+	,
+	With[
+		{
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] :=
+				With[
+					SyntaxExpr[a, "UndefinedSymbol"],
+					SyntaxExpr[a, "UndefinedSymbol"]
+				]
+		},
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+		With
+	] // MakeBoxes
+	,
+	TestID -> "With[{a := With[a, a]}, With]"
+]
+Test[
+	With[{a = Module[{}, a]}, a Module] // MakeBoxes // AnnotateSyntax
+	,
+	With[
+		{
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] =
+				Module[{},
+					SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+				]
+		},
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+		Module
+	] // MakeBoxes
+	,
+	TestID -> "With[{a = Module[{}, a]}, With]"
+]
+
+
+(* ::Subsubsection:: *)
+(*Multiple vars*)
+
+
+Test[
+	Module[{With, a, b := With[{b := a}, a]}, a b With] //
+		MakeBoxes // AnnotateSyntax
+	,
+	Module[
+		{
+			SyntaxExpr[With, "LocalVariable"],
+			SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"],
+			SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"] :=
+				With[
+					{
+						SyntaxExpr[b,
+							"LocalScopeConflict", "LocalVariable",
+							"UndefinedSymbol"
+						] :=
+							SyntaxExpr[a, "UndefinedSymbol"]
+					},
+					SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"]
+				]
+		},
+		SyntaxExpr[a, "LocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[b, "LocalVariable", "UndefinedSymbol"] *
+		SyntaxExpr[With, "LocalVariable"]
+	] // MakeBoxes
+	,
+	TestID -> "Module[{With, a, b := With[{b := a}, a]}, a b With]"
 ]
 
 

--- a/SyntaxAnnotations/Tests/Integration/suite.mt
+++ b/SyntaxAnnotations/Tests/Integration/suite.mt
@@ -6,6 +6,7 @@ TestSuite[{
 	"PatternsDelayed.mt",
 	"PatternsDelayedNested.mt",
 	"Function.mt",
+	"FunctionNested.mt",
 	"Functions.mt",
 	"FunctionsNested.mt",
 	"Strings.mt",

--- a/SyntaxAnnotations/Tests/suite.mt
+++ b/SyntaxAnnotations/Tests/suite.mt
@@ -12,6 +12,7 @@ TestSuite[{
 	"Integration/PatternsDelayed.mt",
 	"Integration/PatternsDelayedNested.mt",
 	"Integration/Function.mt",
+	"Integration/FunctionNested.mt",
 	"Integration/Functions.mt",
 	"Integration/FunctionsNested.mt",
 	"Integration/Strings.mt",


### PR DESCRIPTION
* Add support for parsing modes, add special mode for parsing left hand sides of assignments.

* Add `parseScopingVars` a separate parser for first argument of `With`, `Module` and `Block` taking into account fact that variables on right hand side of assignments are not local variables.

* Split "PatternName" local variable type to "Rules" and "Assignment" since they behave differently.

* Change `extractLocalVariableNames` so that it no longer treats variables found in inner scoping construct as local variables for outer construct.

* Parse function names without local variables of this function assigned. So that if symbol being head of expression is also local variable inside this expression, then head is not annotated as local
variable.

* Syntax types gathering and normalization overhaul. Append types instead of prepending them.

* Add tests for above changes.