### PR TITLE
Localize stringBoxTypes and deafultStringBoxTypes functions

### DIFF
--- a/SyntaxAnnotations/SyntaxAnnotations.m
+++ b/SyntaxAnnotations/SyntaxAnnotations.m
@@ -1200,13 +1200,6 @@ AnnotateSyntax[boxes_, OptionsPattern[]] :=
 			commentPlaceholder, boxesCommRepl, commPos, boxesComm, ignoredPos,
 			boxesClean, boxesCleanParsed, syntaxPosClean, syntaxPos
 		},
-		Function[{lhs, rhs},
-			deafultStringBoxTypes[lhs] := rhs;
-			stringBoxTypes[lhs] := rhs
-			,
-			HoldAll
-		] @@@
-			stringBoxToTypes;
 		
 		boxesCommRepl =
 			boxes /. RowBox[{"(*", ___, "*)"}] -> commentPlaceholder;
@@ -1225,7 +1218,17 @@ AnnotateSyntax[boxes_, OptionsPattern[]] :=
 		boxesClean = Delete[boxesCommRepl, ignoredPos];
 		If[{boxesClean} === {}, Return[boxesComm, Module]];
 		
-		boxesCleanParsed = parse["Main"][boxesClean];
+		Internal`InheritedBlock[{deafultStringBoxTypes, stringBoxTypes},
+			Function[{lhs, rhs},
+				deafultStringBoxTypes[lhs] := rhs;
+				stringBoxTypes[lhs] := rhs
+				,
+				HoldAll
+			] @@@
+				stringBoxToTypes;
+			boxesCleanParsed = parse["Main"][boxesClean]
+		];
+		
 		syntaxPosClean =
 			Position[boxesCleanParsed, _syntaxBox, Heads -> False];
 		syntaxPos =

--- a/SyntaxAnnotations/Tests/Unit/AnnotateSyntax.mt
+++ b/SyntaxAnnotations/Tests/Unit/AnnotateSyntax.mt
@@ -1,0 +1,62 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["SyntaxAnnotations`Tests`Unit`AnnotateSyntax`", {"MUnit`"}]
+
+
+Get["SyntaxAnnotations`"]
+
+PrependTo[$ContextPath, "SyntaxAnnotations`Private`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+Module[
+	{
+		annotation, type,
+		deafultStringBoxTypesDownValues = DownValues[deafultStringBoxTypes],
+		stringBoxTypesDownValues = DownValues[stringBoxTypes]
+	},
+	Test[
+		AnnotateSyntax["testStringBox",
+			"Annotation" -> annotation,
+			"StringBoxToTypes" -> {"testStringBox" -> {type}}
+		]
+		,
+		annotation["testStringBox", {type}]
+		,
+		TestID -> "AnnotateSyntax: options"
+	];
+	
+	Test[
+		DownValues[deafultStringBoxTypes]
+		,
+		deafultStringBoxTypesDownValues
+		,
+		TestID -> "deafultStringBoxTypes DownValues"
+	];
+	Test[
+		DownValues[stringBoxTypes]
+		,
+		stringBoxTypesDownValues
+		,
+		TestID -> "stringBoxTypes DownValues"
+	]
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/SyntaxAnnotations/Tests/Unit/suite.mt
+++ b/SyntaxAnnotations/Tests/Unit/suite.mt
@@ -3,5 +3,6 @@ TestSuite[{
 	"symbolNameQ.mt",
 	"whitespaceQ.mt",
 	"extractSymbolName.mt",
-	"extractArgs.mt"
+	"extractArgs.mt",
+	"AnnotateSyntax.mt"
 }]

--- a/SyntaxAnnotations/Tests/suite.mt
+++ b/SyntaxAnnotations/Tests/suite.mt
@@ -3,7 +3,8 @@ TestSuite[{
 	"Unit/symbolNameQ.mt",
 	"Unit/whitespaceQ.mt",
 	"Unit/extractSymbolName.mt",
-	"Unit/extractArgs.mt"
+	"Unit/extractArgs.mt",
+	"Unit/AnnotateSyntax.mt"
 	,
 	"Integration/Scoping.mt",
 	"Integration/ScopingNested.mt",


### PR DESCRIPTION
Their `DownValues` are dynamically added inside `AnnotateSyntax` function based on given options, so they should be localized.